### PR TITLE
Implement multi instance network

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -58,6 +58,8 @@ dependencies {
     compileOnly(files("libs/Residence5.1.4.0.jar"))
     compileOnly(files("libs/TAB v4.1.2.jar"))
 
+    implementation("org.java-websocket:Java-WebSocket:1.5.6")
+
     //compileOnly("dev.majek:hexnicks:3.1.1")
 
     implementation("org.bstats:bstats-bukkit:${project.property("bstats_version")}")

--- a/src/main/java/xiamomc/morph/MorphManager.java
+++ b/src/main/java/xiamomc/morph/MorphManager.java
@@ -39,6 +39,8 @@ import xiamomc.morph.network.commands.S2C.map.S2CMapCommand;
 import xiamomc.morph.network.commands.S2C.map.S2CMapRemoveCommand;
 import xiamomc.morph.network.commands.S2C.map.S2CPartialMapCommand;
 import xiamomc.morph.network.commands.S2C.set.*;
+import xiamomc.morph.network.multiInstance.MultiInstanceService;
+import xiamomc.morph.network.multiInstance.protocol.Operation;
 import xiamomc.morph.network.server.MorphClientHandler;
 import xiamomc.morph.providers.DisguiseProvider;
 import xiamomc.morph.providers.FallbackProvider;
@@ -80,6 +82,9 @@ public class MorphManager extends MorphPluginObject implements IManagePlayerData
 
     @Resolved
     private NetworkingHelper networkingHelper;
+
+    @Resolved
+    private MultiInstanceService multiInstanceService;
 
     public static final DisguiseProvider fallbackProvider = new FallbackProvider();
 
@@ -1390,6 +1395,7 @@ public class MorphManager extends MorphPluginObject implements IManagePlayerData
         if (success)
         {
             clientHandler.sendDiff(List.of(disguiseIdentifier), null, player);
+            multiInstanceService.notifyDisguiseMetaChange(player.getUniqueId(), Operation.ADD_IF_ABSENT, disguiseIdentifier);
 
             var config = data.getPlayerMeta(player);
 
@@ -1417,7 +1423,10 @@ public class MorphManager extends MorphPluginObject implements IManagePlayerData
         var success = data.revokeMorphFromPlayer(player, disguiseIdentifier);
 
         if (success)
+        {
             clientHandler.sendDiff(null, List.of(disguiseIdentifier), player);
+            multiInstanceService.notifyDisguiseMetaChange(player.getUniqueId(), Operation.REMOVE, disguiseIdentifier);
+        }
 
         return success;
     }
@@ -1480,4 +1489,10 @@ public class MorphManager extends MorphPluginObject implements IManagePlayerData
         return data.saveConfiguration() && offlineStorage.saveConfiguration();
     }
     //endregion Implementation of IManagePlayerData
+
+    @ApiStatus.Internal
+    public List<PlayerMeta> listAllPlayerMeta()
+    {
+        return data.getAll();
+    }
 }

--- a/src/main/java/xiamomc/morph/MorphPlugin.java
+++ b/src/main/java/xiamomc/morph/MorphPlugin.java
@@ -20,6 +20,7 @@ import xiamomc.morph.misc.NetworkingHelper;
 import xiamomc.morph.misc.PlayerOperationSimulator;
 import xiamomc.morph.misc.integrations.residence.ResidenceEventProcessor;
 import xiamomc.morph.misc.integrations.tab.TabAdapter;
+import xiamomc.morph.network.multiInstance.MultiInstanceService;
 import xiamomc.morph.updates.UpdateHandler;
 import xiamomc.morph.misc.integrations.placeholderapi.PlaceholderIntegration;
 import xiamomc.morph.network.server.MorphClientHandler;
@@ -83,6 +84,8 @@ public final class MorphPlugin extends XiaMoJavaPlugin
     private InteractionMirrorProcessor mirrorProcessor;
 
     private TabAdapter tabAdapter;
+
+    private MultiInstanceService instanceService;
 
     @Override
     public void onEnable()
@@ -164,6 +167,8 @@ public final class MorphPlugin extends XiaMoJavaPlugin
         var updateHandler = new UpdateHandler();
         dependencyManager.cache(updateHandler);
 
+        dependencyManager.cache(instanceService = new MultiInstanceService());
+
         mirrorProcessor = new InteractionMirrorProcessor();
 
         //注册EventProcessor
@@ -214,6 +219,9 @@ public final class MorphPlugin extends XiaMoJavaPlugin
 
             if (mirrorProcessor != null)
                 mirrorProcessor.pushToLoggingBase();
+
+            if (instanceService != null)
+                instanceService.onDisable();
 
             var messenger = this.getServer().getMessenger();
 

--- a/src/main/java/xiamomc/morph/config/ConfigOption.java
+++ b/src/main/java/xiamomc/morph/config/ConfigOption.java
@@ -93,6 +93,12 @@ public enum ConfigOption
 
     UUID_RANDOM_BASE(ConfigNode.create().append("uuid_random_base"), RandomStringUtils.randomAlphabetic(8)),
 
+    MASTER_ADDRESS(multiInstanceNode().append("master_address"), "0.0.0.0:39210"),
+
+    IS_MASTER(multiInstanceNode().append("is_master_service"), false),
+
+    MASTER_SECRET(multiInstanceNode().append("secret"), RandomStringUtils.randomAlphabetic(12)),
+
     VERSION(ConfigNode.create().append("version"), 0);
 
     public final ConfigNode node;
@@ -161,5 +167,9 @@ public enum ConfigOption
     private static ConfigNode boundingBoxNode()
     {
         return ConfigNode.create().append("bounding_boxes");
+    }
+    private static ConfigNode multiInstanceNode()
+    {
+        return ConfigNode.create().append("multi_instance");
     }
 }

--- a/src/main/java/xiamomc/morph/network/ReasonCodes.java
+++ b/src/main/java/xiamomc/morph/network/ReasonCodes.java
@@ -1,0 +1,6 @@
+package xiamomc.morph.network;
+
+public class ReasonCodes
+{
+    public static int DISCONNECT = 1000;
+}

--- a/src/main/java/xiamomc/morph/network/multiInstance/IInstanceService.java
+++ b/src/main/java/xiamomc/morph/network/multiInstance/IInstanceService.java
@@ -1,0 +1,9 @@
+package xiamomc.morph.network.multiInstance;
+
+public interface IInstanceService
+{
+    /**
+     * @return Whether this operation operates successfully
+     */
+    public boolean stop();
+}

--- a/src/main/java/xiamomc/morph/network/multiInstance/MultiInstanceService.java
+++ b/src/main/java/xiamomc/morph/network/multiInstance/MultiInstanceService.java
@@ -1,0 +1,102 @@
+package xiamomc.morph.network.multiInstance;
+
+import org.jetbrains.annotations.Nullable;
+import xiamomc.morph.MorphPluginObject;
+import xiamomc.morph.config.ConfigOption;
+import xiamomc.morph.config.MorphConfigManager;
+import xiamomc.morph.network.multiInstance.master.MasterInstance;
+import xiamomc.morph.network.multiInstance.protocol.Operation;
+import xiamomc.morph.network.multiInstance.protocol.c2s.MIC2SDisguiseMetaCommand;
+import xiamomc.morph.network.multiInstance.protocol.s2c.MIS2CDisguiseMetaCommand;
+import xiamomc.morph.network.multiInstance.slave.SlaveInstance;
+import xiamomc.pluginbase.Annotations.Initializer;
+import xiamomc.pluginbase.Bindables.Bindable;
+
+import java.util.Arrays;
+import java.util.UUID;
+
+public class MultiInstanceService extends MorphPluginObject
+{
+    @Nullable
+    private MasterInstance masterInstance;
+
+    @Nullable
+    private SlaveInstance slaveInstance;
+
+    private void checkSanity()
+    {
+        if (masterInstance != null && slaveInstance != null)
+            throw new IllegalStateException("Master instance and Slave instance are both not null, which is not good!");
+
+        if (masterInstance == null && slaveInstance == null)
+            throw new IllegalStateException("None of master or slave instance is alive!");
+
+        if (isMaster.get() && masterInstance == null)
+            throw new IllegalStateException("We are the master server, but the server instance is null?!");
+
+        if (!isMaster.get() && slaveInstance == null)
+            throw new IllegalStateException("We are the client, but the client instance is null?!");
+    }
+
+    private void prepareInstance(boolean isMaster)
+    {
+        logger.info("Preparing socket instance...");
+
+        if (!stopAll())
+        {
+            logger.warn("Can't stop instance, not continuing...");
+
+            masterInstance = null;
+            slaveInstance = null;
+
+            return;
+        }
+
+        masterInstance = null;
+        slaveInstance = null;
+
+        if (isMaster)
+            masterInstance = new MasterInstance();
+        else
+            slaveInstance = new SlaveInstance();
+    }
+
+    private final Bindable<Boolean> isMaster = new Bindable<>(false);
+
+    @Initializer
+    private void load(MorphConfigManager configManager)
+    {
+        configManager.bind(isMaster, ConfigOption.IS_MASTER);
+
+        isMaster.onValueChanged((o, n) -> prepareInstance(n), true);
+    }
+
+    public void onDisable()
+    {
+        stopAll();
+    }
+
+    public void notifyDisguiseMetaChange(UUID uuid, Operation operation, String... identifiers)
+    {
+        checkSanity();
+
+        if (isMaster.get())
+        {
+            assert masterInstance != null;
+            masterInstance.broadcastCommand(new MIS2CDisguiseMetaCommand(operation, Arrays.stream(identifiers).toList(), uuid));
+        }
+        else
+        {
+            assert slaveInstance != null;
+            slaveInstance.sendCommand(new MIC2SDisguiseMetaCommand(operation, Arrays.stream(identifiers).toList(), uuid));
+        }
+    }
+
+    private boolean stopAll()
+    {
+        if (masterInstance != null) return masterInstance.stop();
+        if (slaveInstance != null) return slaveInstance.stop();
+
+        return true;
+    }
+}

--- a/src/main/java/xiamomc/morph/network/multiInstance/MultiInstanceService.java
+++ b/src/main/java/xiamomc/morph/network/multiInstance/MultiInstanceService.java
@@ -7,7 +7,7 @@ import xiamomc.morph.config.MorphConfigManager;
 import xiamomc.morph.network.multiInstance.master.MasterInstance;
 import xiamomc.morph.network.multiInstance.protocol.Operation;
 import xiamomc.morph.network.multiInstance.protocol.c2s.MIC2SDisguiseMetaCommand;
-import xiamomc.morph.network.multiInstance.protocol.s2c.MIS2CDisguiseMetaCommand;
+import xiamomc.morph.network.multiInstance.protocol.s2c.MIS2CSyncMetaCommand;
 import xiamomc.morph.network.multiInstance.slave.SlaveInstance;
 import xiamomc.pluginbase.Annotations.Initializer;
 import xiamomc.pluginbase.Bindables.Bindable;
@@ -83,7 +83,7 @@ public class MultiInstanceService extends MorphPluginObject
         if (isMaster.get())
         {
             assert masterInstance != null;
-            masterInstance.broadcastCommand(new MIS2CDisguiseMetaCommand(operation, Arrays.stream(identifiers).toList(), uuid));
+            masterInstance.broadcastCommand(new MIS2CSyncMetaCommand(operation, Arrays.stream(identifiers).toList(), uuid));
         }
         else
         {

--- a/src/main/java/xiamomc/morph/network/multiInstance/master/InstanceServer.java
+++ b/src/main/java/xiamomc/morph/network/multiInstance/master/InstanceServer.java
@@ -71,7 +71,7 @@ public final class InstanceServer extends WebSocketServer
     @Override
     public void onMessage(WebSocket webSocket, String msg)
     {
-        logger.info("%s :: <- :: '%s'".formatted(webSocket.getRemoteSocketAddress(), msg));
+        //logger.info("%s :: <- :: '%s'".formatted(webSocket.getRemoteSocketAddress(), msg));
 
         clientHandler.onMessage(new WsRecord(webSocket, msg), this);
     }

--- a/src/main/java/xiamomc/morph/network/multiInstance/master/InstanceServer.java
+++ b/src/main/java/xiamomc/morph/network/multiInstance/master/InstanceServer.java
@@ -1,0 +1,95 @@
+package xiamomc.morph.network.multiInstance.master;
+
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+import org.java_websocket.WebSocket;
+import org.java_websocket.handshake.ClientHandshake;
+import org.java_websocket.server.WebSocketServer;
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import xiamomc.morph.config.MorphConfigManager;
+import xiamomc.morph.network.multiInstance.protocol.IClientHandler;
+import xiamomc.pluginbase.Managers.DependencyManager;
+import xiamomc.pluginbase.XiaMoJavaPlugin;
+
+import java.net.InetSocketAddress;
+import java.util.List;
+
+public final class InstanceServer extends WebSocketServer
+{
+    private final Logger logger;
+
+    @Nullable
+    private MorphConfigManager config;
+
+    private IClientHandler clientHandler;
+
+    public InstanceServer(XiaMoJavaPlugin plugin, InetSocketAddress address, IClientHandler iClientHandler)
+    {
+        super(address);
+
+        this.logger = plugin.getSLF4JLogger();
+
+        var dependencies = DependencyManager.getManagerOrCreate(plugin);
+        config = dependencies.get(MorphConfigManager.class, false);
+
+        this.clientHandler = iClientHandler;
+
+        plugin.schedule(this::load);
+    }
+
+    private void load()
+    {
+    }
+
+    private final List<WebSocket> connectedSockets = new ObjectArrayList<>();
+
+    public List<WebSocket> getConnectedSockets()
+    {
+        return new ObjectArrayList<>(connectedSockets);
+    }
+
+    @Override
+    public void onOpen(WebSocket webSocket, ClientHandshake clientHandshake)
+    {
+        logger.info("New connection opened: " + webSocket.getRemoteSocketAddress());
+
+        connectedSockets.add(webSocket);
+    }
+
+    @Override
+    public void onClose(WebSocket webSocket, int i, String s, boolean b)
+    {
+        logger.info("Connection closed: " + webSocket.getRemoteSocketAddress());
+
+        connectedSockets.remove(webSocket);
+    }
+
+    public record WsRecord(WebSocket socket, String rawMessage)
+    {
+    }
+
+    @Override
+    public void onMessage(WebSocket webSocket, String msg)
+    {
+        logger.info("%s :: <- :: '%s'".formatted(webSocket.getRemoteSocketAddress(), msg));
+
+        clientHandler.onMessage(new WsRecord(webSocket, msg), this);
+    }
+
+    @Override
+    public void onError(WebSocket webSocket, Exception e)
+    {
+        logger.warn("An error occurred with socket '%s': %s".formatted(webSocket.getRemoteSocketAddress(), e.getMessage()));
+        e.printStackTrace();
+    }
+
+    @Override
+    public void onStart()
+    {
+        logger.info("Master websocket server started on " + this.getAddress().toString());
+    }
+
+    public void dispose()
+    {
+    }
+}

--- a/src/main/java/xiamomc/morph/network/multiInstance/master/InstanceServer.java
+++ b/src/main/java/xiamomc/morph/network/multiInstance/master/InstanceServer.java
@@ -18,20 +18,13 @@ public final class InstanceServer extends WebSocketServer
 {
     private final Logger logger;
 
-    @Nullable
-    private MorphConfigManager config;
-
-    private IClientHandler clientHandler;
+    private final IClientHandler clientHandler;
 
     public InstanceServer(XiaMoJavaPlugin plugin, InetSocketAddress address, IClientHandler iClientHandler)
     {
         super(address);
 
         this.logger = plugin.getSLF4JLogger();
-
-        var dependencies = DependencyManager.getManagerOrCreate(plugin);
-        config = dependencies.get(MorphConfigManager.class, false);
-
         this.clientHandler = iClientHandler;
 
         plugin.schedule(this::load);
@@ -87,6 +80,8 @@ public final class InstanceServer extends WebSocketServer
     public void onStart()
     {
         logger.info("Master websocket server started on " + this.getAddress().toString());
+
+        clientHandler.onServerStart(this);
     }
 
     public void dispose()

--- a/src/main/java/xiamomc/morph/network/multiInstance/master/MasterInstance.java
+++ b/src/main/java/xiamomc/morph/network/multiInstance/master/MasterInstance.java
@@ -1,0 +1,324 @@
+package xiamomc.morph.network.multiInstance.master;
+
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+import org.bukkit.Bukkit;
+import org.java_websocket.WebSocket;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Nullable;
+import xiamomc.morph.MorphManager;
+import xiamomc.morph.MorphPluginObject;
+import xiamomc.morph.config.ConfigOption;
+import xiamomc.morph.config.MorphConfigManager;
+import xiamomc.morph.network.ReasonCodes;
+import xiamomc.morph.network.commands.CommandRegistries;
+import xiamomc.morph.network.multiInstance.IInstanceService;
+import xiamomc.morph.network.multiInstance.protocol.IClientHandler;
+import xiamomc.morph.network.multiInstance.protocol.Operation;
+import xiamomc.morph.network.multiInstance.protocol.ProtocolLevel;
+import xiamomc.morph.network.multiInstance.protocol.c2s.MIC2SCommand;
+import xiamomc.morph.network.multiInstance.protocol.c2s.MIC2SDisguiseMetaCommand;
+import xiamomc.morph.network.multiInstance.protocol.s2c.MIS2CCommand;
+import xiamomc.morph.network.multiInstance.protocol.c2s.MIC2SLoginCommand;
+import xiamomc.morph.network.multiInstance.protocol.s2c.MIS2CDisconnectCommand;
+import xiamomc.morph.network.multiInstance.protocol.s2c.MIS2CDisguiseMetaCommand;
+import xiamomc.morph.network.multiInstance.protocol.s2c.MIS2CLoginResultCommand;
+import xiamomc.morph.network.server.MorphClientHandler;
+import xiamomc.pluginbase.Annotations.Initializer;
+import xiamomc.pluginbase.Annotations.Resolved;
+import xiamomc.pluginbase.Bindables.Bindable;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+
+public class MasterInstance extends MorphPluginObject implements IInstanceService, IClientHandler
+{
+    @Nullable
+    private InstanceServer bindingServer;
+
+    @Resolved
+    private MorphConfigManager config;
+
+    /**
+     * @return Success?
+     */
+    private boolean stopServer()
+    {
+        try
+        {
+            if (bindingServer != null)
+            {
+                bindingServer.dispose();
+                bindingServer.stop(1000, "Master instance shutting down");
+            }
+
+            bindingServer = null;
+
+            return true;
+        }
+        catch (Throwable t)
+        {
+            logger.error("Error occurred shutting down socket server: " + t.getMessage());
+            t.printStackTrace();
+
+            return false;
+        }
+    }
+
+    /**
+     * @return Whether this operation operates successfully
+     */
+    private boolean prepareServer()
+    {
+        if (!stopServer())
+            return false;
+
+        try
+        {
+            String[] configuredAddress = config.getOrDefault(String.class, ConfigOption.MASTER_ADDRESS).split(":");
+
+            String host = configuredAddress[0];
+            int port = Integer.parseInt( configuredAddress.length >= 2 ? configuredAddress[1] : "39210" );
+            var addr = new InetSocketAddress(InetAddress.getByName(host), port);
+
+            bindingServer = new InstanceServer(plugin, addr, this);
+            bindingServer.start();
+
+            return true;
+        }
+        catch (Throwable t)
+        {
+            logger.warn("Error occurred while setting up server:" + t.getMessage());
+            t.printStackTrace();
+
+            return false;
+        }
+    }
+
+    private final Bindable<String> secret = new Bindable<>(null);
+
+    @Initializer
+    private void load()
+    {
+        logger.info("Preparing multi-instance service...");
+
+        config.bind(secret, ConfigOption.MASTER_SECRET);
+
+        registries.registerC2S("login", MIC2SLoginCommand::from)
+                .registerC2S("dmeta", MIC2SDisguiseMetaCommand::from);
+
+        if (!prepareServer())
+        {
+            logger.error("Can't setup server, not enabling multi-instance service!");
+            return;
+        }
+    }
+
+    //region IInstanceService
+
+    @Override
+    public boolean stop()
+    {
+        return stopServer();
+    }
+
+    //endregion
+
+    private void onText(InstanceServer.WsRecord record)
+    {
+        var ws = record.socket();
+        var text = record.rawMessage().split(" ", 2);
+
+        logger.info("Get command from " + ws.getRemoteSocketAddress().toString() + ": " + record.rawMessage());
+
+        var cmd = registries.createC2SCommand(text[0], text.length == 2 ? text[1] : "");
+        if (cmd == null)
+        {
+            logger.warn("Unknown command: " + text[0]);
+            return;
+        }
+
+        if (!(cmd instanceof MIC2SCommand<?> mic2s))
+        {
+            logger.warn("Command is not a MIC2S instance!");
+            return;
+        }
+
+        mic2s.setSourceSocket(ws);
+        mic2s.onCommand(this);
+    }
+
+    //region IClientHandler
+
+    private final CommandRegistries registries = new CommandRegistries();
+
+    private final ProtocolLevel level = ProtocolLevel.V1;
+
+    private final List<WebSocket> allowedSockets = new ObjectArrayList<>();
+
+    @ApiStatus.Internal
+    public void broadcastCommand(MIS2CCommand<?> command)
+    {
+        for (var allowedSocket : this.allowedSockets)
+            this.sendCommand(allowedSocket, command);
+    }
+
+    private void sendCommand(WebSocket socket, MIS2CCommand<?> command)
+    {
+        if (silent) return;
+
+        if (!socket.isOpen())
+        {
+            logger.warn("Not sending a command to a closed socket!");
+            return;
+        }
+
+        logger.info("%s :: -> :: %s".formatted(socket.getRemoteSocketAddress(), command.buildCommand()));
+
+        socket.send(command.buildCommand());
+    }
+
+    private void disconnect(WebSocket socket, String reason)
+    {
+        this.sendCommand(socket, new MIS2CDisconnectCommand(ReasonCodes.DISCONNECT, reason));
+        socket.close();
+    }
+
+    private boolean socketAllowed(WebSocket socket)
+    {
+        return allowedSockets.contains(socket);
+    }
+
+    @Override
+    public void onLoginCommand(MIC2SLoginCommand cProtocolCommand)
+    {
+        logger.info("'%s' is requesting a login!".formatted(cProtocolCommand.getSocket()));
+
+        var socket = cProtocolCommand.getSocket();
+        if (socket == null)
+            return;
+
+        logger.info("Level is '%s', and their secret is '%s'".formatted(cProtocolCommand.getVersion(), cProtocolCommand.getSecret()));
+
+        if (!this.level.equals(cProtocolCommand.getVersion()))
+        {
+            logger.info("Protocol mismatch!");
+            this.disconnect(socket, "Protocol mismatch!");
+            return;
+        }
+
+        if (cProtocolCommand.getSecret() == null || !cProtocolCommand.getSecret().equals(this.secret.get()))
+        {
+            logger.info("Invalid secret! Disconnecting...");
+
+            disconnect(socket, "Invalid secret '%s'".formatted(cProtocolCommand.getSecret()));
+            return;
+        }
+
+        allowedSockets.add(socket);
+        sendCommand(socket, new MIS2CLoginResultCommand(true));
+
+        var cmds = new ObjectArrayList<MIS2CDisguiseMetaCommand>();
+        var disguises = morphManager.listAllPlayerMeta();
+        for (var meta : disguises)
+        {
+            var identifiers = meta.getUnlockedDisguiseIdentifiers();
+
+            if (!identifiers.isEmpty())
+                cmds.add(new MIS2CDisguiseMetaCommand(Operation.ADD_IF_ABSENT, identifiers, meta.uniqueId));
+        }
+
+        cmds.forEach(cmd -> this.sendCommand(socket, cmd));
+    }
+
+    @Resolved
+    private MorphManager morphManager;
+
+    @Resolved
+    private MorphClientHandler clientHandler;
+
+    @Override
+    public void onDisguiseMetaCommand(MIC2SDisguiseMetaCommand cDisguiseMetaCommand)
+    {
+        var socket = cDisguiseMetaCommand.getSocket();
+        if (!socketAllowed(socket))
+            return;
+
+        assert socket != null;
+
+        var meta = cDisguiseMetaCommand.getMeta();
+        if (meta == null || !meta.isValid())
+        {
+            logger.warn("Got invalid meta from '%s'".formatted(socket.getRemoteSocketAddress()));
+            return;
+        }
+
+        var operation = meta.getOperation();
+        var identifiers = meta.getIdentifiers();
+
+        var playerMeta = morphManager.getPlayerMeta(Bukkit.getOfflinePlayer(Objects.requireNonNull(meta.getBindingUuid(), "???")));
+        var unlocked = playerMeta.getUnlockedDisguises();
+
+        var player = Bukkit.getPlayer(meta.getBindingUuid());
+
+        if (operation == Operation.ADD_IF_ABSENT)
+        {
+            identifiers.forEach(id ->
+            {
+                var disguiseMeta = morphManager.getDisguiseMeta(id);
+
+                if (!unlocked.contains(disguiseMeta))
+                    playerMeta.addDisguise(disguiseMeta);
+
+                if (player != null)
+                    clientHandler.refreshPlayerClientMorphs(playerMeta.getUnlockedDisguiseIdentifiers(), player);
+            });
+
+            // Broadcast to all allow sockets
+            for (var allowedSocket : this.allowedSockets)
+            {
+                if (allowedSocket == cDisguiseMetaCommand.getSocket())
+                    continue;
+
+                this.sendCommand(allowedSocket, new MIS2CDisguiseMetaCommand(meta));
+            }
+        }
+        else if (operation == Operation.REMOVE)
+        {
+            identifiers.forEach(id ->
+            {
+                var disguiseMeta = morphManager.getDisguiseMeta(id);
+
+                playerMeta.removeDisguise(disguiseMeta);
+            });
+
+            if (player != null)
+                clientHandler.refreshPlayerClientMorphs(playerMeta.getUnlockedDisguiseIdentifiers(), player);
+
+            // Broadcast to all allow sockets
+            for (var allowedSocket : this.allowedSockets)
+            {
+                if (allowedSocket == cDisguiseMetaCommand.getSocket())
+                    continue;
+
+                this.sendCommand(allowedSocket, new MIS2CDisguiseMetaCommand(meta));
+            }
+        }
+    }
+
+    @Override
+    public void onMessage(InstanceServer.WsRecord wsRecord, InstanceServer server)
+    {
+        this.addSchedule(() -> this.onText(wsRecord));
+    }
+
+    //endregion
+
+    //region Utilities
+
+    private boolean silent = false;
+
+    //endregion
+}

--- a/src/main/java/xiamomc/morph/network/multiInstance/master/NetworkDisguiseManager.java
+++ b/src/main/java/xiamomc/morph/network/multiInstance/master/NetworkDisguiseManager.java
@@ -1,0 +1,47 @@
+package xiamomc.morph.network.multiInstance.master;
+
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+import org.bukkit.OfflinePlayer;
+import xiamomc.morph.MorphPluginObject;
+import xiamomc.morph.misc.DisguiseMeta;
+import xiamomc.morph.misc.DisguiseTypes;
+import xiamomc.morph.storage.playerdata.PlayerMeta;
+
+import java.util.List;
+
+public class NetworkDisguiseManager extends MorphPluginObject
+{
+    private final List<PlayerMeta> storedMeta = new ObjectArrayList<>();
+
+    public List<PlayerMeta> listAllMeta()
+    {
+        return new ObjectArrayList<>(storedMeta);
+    }
+
+    public PlayerMeta getPlayerMeta(OfflinePlayer player)
+    {
+        var match = storedMeta.stream()
+                .filter(m -> m.uniqueId.equals(player.getUniqueId()))
+                .findFirst().orElse(null);
+
+        if (match != null) return match;
+
+        var newInstance = new PlayerMeta();
+        newInstance.uniqueId = player.getUniqueId();
+        storedMeta.add(newInstance);
+
+        return newInstance;
+    }
+
+    private final List<DisguiseMeta> cachedMetas = new ObjectArrayList<>();
+
+    public DisguiseMeta getDisguiseMeta(String rawString)
+    {
+        var type = DisguiseTypes.fromId(rawString);
+
+        if (this.cachedMetas.stream().noneMatch(o -> o.equals(rawString)))
+            cachedMetas.add(new DisguiseMeta(rawString, type));
+
+        return cachedMetas.stream().filter(o -> o.equals(rawString)).findFirst().orElse(null);
+    }
+}

--- a/src/main/java/xiamomc/morph/network/multiInstance/master/NetworkDisguiseManager.java
+++ b/src/main/java/xiamomc/morph/network/multiInstance/master/NetworkDisguiseManager.java
@@ -44,4 +44,26 @@ public class NetworkDisguiseManager extends MorphPluginObject
 
         return cachedMetas.stream().filter(o -> o.equals(rawString)).findFirst().orElse(null);
     }
+
+    public void merge(List<PlayerMeta> other)
+    {
+        for (var otherMeta : other)
+        {
+            var match = storedMeta.stream()
+                    .filter(meta -> meta.uniqueId.equals(otherMeta.uniqueId))
+                    .findFirst().orElse(null);
+
+            if (match == null)
+            {
+                var newInstance = new PlayerMeta();
+                newInstance.uniqueId = otherMeta.uniqueId;
+                newInstance.getUnlockedDisguiseIdentifiers().addAll(otherMeta.getUnlockedDisguiseIdentifiers());
+                storedMeta.add(newInstance);
+
+                continue;
+            }
+
+            match.getUnlockedDisguiseIdentifiers().addAll(otherMeta.getUnlockedDisguiseIdentifiers());
+        }
+    }
 }

--- a/src/main/java/xiamomc/morph/network/multiInstance/protocol/IClientHandler.java
+++ b/src/main/java/xiamomc/morph/network/multiInstance/protocol/IClientHandler.java
@@ -1,0 +1,14 @@
+package xiamomc.morph.network.multiInstance.protocol;
+
+import xiamomc.morph.network.multiInstance.master.InstanceServer;
+import xiamomc.morph.network.multiInstance.protocol.c2s.MIC2SDisguiseMetaCommand;
+import xiamomc.morph.network.multiInstance.protocol.c2s.MIC2SLoginCommand;
+
+public interface IClientHandler
+{
+    public void onLoginCommand(MIC2SLoginCommand cProtocolCommand);
+
+    public void onDisguiseMetaCommand(MIC2SDisguiseMetaCommand cDisguiseMetaCommand);
+
+    public void onMessage(InstanceServer.WsRecord wsRecord, InstanceServer server);
+}

--- a/src/main/java/xiamomc/morph/network/multiInstance/protocol/IClientHandler.java
+++ b/src/main/java/xiamomc/morph/network/multiInstance/protocol/IClientHandler.java
@@ -11,4 +11,6 @@ public interface IClientHandler
     public void onDisguiseMetaCommand(MIC2SDisguiseMetaCommand cDisguiseMetaCommand);
 
     public void onMessage(InstanceServer.WsRecord wsRecord, InstanceServer server);
+
+    public void onServerStart(InstanceServer server);
 }

--- a/src/main/java/xiamomc/morph/network/multiInstance/protocol/IMasterHandler.java
+++ b/src/main/java/xiamomc/morph/network/multiInstance/protocol/IMasterHandler.java
@@ -1,0 +1,18 @@
+package xiamomc.morph.network.multiInstance.protocol;
+
+import xiamomc.morph.network.multiInstance.protocol.s2c.MIS2CDisconnectCommand;
+import xiamomc.morph.network.multiInstance.protocol.s2c.MIS2CDisguiseMetaCommand;
+import xiamomc.morph.network.multiInstance.protocol.s2c.MIS2CLoginResultCommand;
+import xiamomc.morph.network.multiInstance.protocol.s2c.MIS2CStateCommand;
+
+public interface IMasterHandler
+{
+    public void onDisguiseMetaCommand(MIS2CDisguiseMetaCommand metaCommand);
+
+    public void onDisconnectCommand(MIS2CDisconnectCommand cDenyCommand);
+
+    public void onLoginResultCommand(MIS2CLoginResultCommand cLoginResultCommand);
+
+    public void onConnectionOpen();
+    public void onText(String rawCommand);
+}

--- a/src/main/java/xiamomc/morph/network/multiInstance/protocol/IMasterHandler.java
+++ b/src/main/java/xiamomc/morph/network/multiInstance/protocol/IMasterHandler.java
@@ -4,6 +4,7 @@ import xiamomc.morph.network.multiInstance.protocol.s2c.MIS2CDisconnectCommand;
 import xiamomc.morph.network.multiInstance.protocol.s2c.MIS2CStateCommand;
 import xiamomc.morph.network.multiInstance.protocol.s2c.MIS2CSyncMetaCommand;
 import xiamomc.morph.network.multiInstance.protocol.s2c.MIS2CLoginResultCommand;
+import xiamomc.morph.network.multiInstance.slave.InstanceClient;
 
 public interface IMasterHandler
 {
@@ -16,4 +17,5 @@ public interface IMasterHandler
 
     public void onConnectionOpen();
     public void onText(String rawCommand);
+    public void onClientError(Exception e, InstanceClient client);
 }

--- a/src/main/java/xiamomc/morph/network/multiInstance/protocol/IMasterHandler.java
+++ b/src/main/java/xiamomc/morph/network/multiInstance/protocol/IMasterHandler.java
@@ -1,17 +1,18 @@
 package xiamomc.morph.network.multiInstance.protocol;
 
 import xiamomc.morph.network.multiInstance.protocol.s2c.MIS2CDisconnectCommand;
-import xiamomc.morph.network.multiInstance.protocol.s2c.MIS2CDisguiseMetaCommand;
-import xiamomc.morph.network.multiInstance.protocol.s2c.MIS2CLoginResultCommand;
 import xiamomc.morph.network.multiInstance.protocol.s2c.MIS2CStateCommand;
+import xiamomc.morph.network.multiInstance.protocol.s2c.MIS2CSyncMetaCommand;
+import xiamomc.morph.network.multiInstance.protocol.s2c.MIS2CLoginResultCommand;
 
 public interface IMasterHandler
 {
-    public void onDisguiseMetaCommand(MIS2CDisguiseMetaCommand metaCommand);
+    public void onSyncMetaCommand(MIS2CSyncMetaCommand metaCommand);
 
     public void onDisconnectCommand(MIS2CDisconnectCommand cDenyCommand);
 
     public void onLoginResultCommand(MIS2CLoginResultCommand cLoginResultCommand);
+    public void onStateCommand(MIS2CStateCommand cStateCommand);
 
     public void onConnectionOpen();
     public void onText(String rawCommand);

--- a/src/main/java/xiamomc/morph/network/multiInstance/protocol/Operation.java
+++ b/src/main/java/xiamomc/morph/network/multiInstance/protocol/Operation.java
@@ -1,0 +1,8 @@
+package xiamomc.morph.network.multiInstance.protocol;
+
+public enum Operation
+{
+    ADD_IF_ABSENT,
+    REMOVE,
+    INVALID
+}

--- a/src/main/java/xiamomc/morph/network/multiInstance/protocol/ProtocolLevel.java
+++ b/src/main/java/xiamomc/morph/network/multiInstance/protocol/ProtocolLevel.java
@@ -1,0 +1,53 @@
+package xiamomc.morph.network.multiInstance.protocol;
+
+public enum ProtocolLevel
+{
+    V1(1);
+
+    private final int version;
+
+    ProtocolLevel(int version)
+    {
+        this.version = version;
+    }
+
+    public int version()
+    {
+        return version;
+    }
+
+    public String versionString()
+    {
+        return "" + version;
+    }
+
+    public boolean isNewerThan(ProtocolLevel other)
+    {
+        return this.version > other.version;
+    }
+
+    public boolean isNewerThan(int other)
+    {
+        return this.version > other;
+    }
+
+    public boolean isOlderThan(ProtocolLevel other)
+    {
+        return this.version < other.version;
+    }
+
+    public boolean isOlderThan(int other)
+    {
+        return this.version < other;
+    }
+
+    public boolean equals(ProtocolLevel other)
+    {
+        return this.version == other.version;
+    }
+
+    public boolean equals(int other)
+    {
+        return this.version == other;
+    }
+}

--- a/src/main/java/xiamomc/morph/network/multiInstance/protocol/SocketDisguiseMeta.java
+++ b/src/main/java/xiamomc/morph/network/multiInstance/protocol/SocketDisguiseMeta.java
@@ -1,0 +1,73 @@
+package xiamomc.morph.network.multiInstance.protocol;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.annotations.Expose;
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+import java.util.UUID;
+
+public class SocketDisguiseMeta
+{
+    @Expose
+    @Nullable
+    private Operation operation;
+
+    public Operation getOperation()
+    {
+        return operation == null ? Operation.INVALID : operation;
+    }
+
+    @Expose
+    private List<String> identifiers = new ObjectArrayList<>();
+
+    public List<String> getIdentifiers()
+    {
+        return identifiers;
+    }
+
+    @Expose
+    @Nullable
+    private UUID uuid;
+
+    /**
+     * @return The uuid of the binding player. Not null if valid
+     */
+    @Nullable
+    public UUID getBindingUuid()
+    {
+        return uuid;
+    }
+
+    public boolean isValid()
+    {
+        return uuid != null && operation != Operation.INVALID;
+    }
+
+    public SocketDisguiseMeta()
+    {
+    }
+
+    public SocketDisguiseMeta(@NotNull Operation operation, List<String> ids, @NotNull UUID bindingUUID)
+    {
+        this.operation = operation;
+        this.identifiers.addAll(ids);
+
+        this.uuid = bindingUUID;
+    }
+
+    private static final Gson gson = new GsonBuilder()
+            .disableHtmlEscaping()
+            .excludeFieldsWithoutExposeAnnotation()
+            .create();
+
+    @Override
+    public String toString()
+    {
+        return gson.toJson(this);
+    }
+}
+

--- a/src/main/java/xiamomc/morph/network/multiInstance/protocol/c2s/MIC2SCommand.java
+++ b/src/main/java/xiamomc/morph/network/multiInstance/protocol/c2s/MIC2SCommand.java
@@ -1,0 +1,53 @@
+package xiamomc.morph.network.multiInstance.protocol.c2s;
+
+import org.java_websocket.WebSocket;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import xiamomc.morph.MorphPlugin;
+import xiamomc.morph.network.BasicClientHandler;
+import xiamomc.morph.network.BasicServerHandler;
+import xiamomc.morph.network.commands.C2S.AbstractC2SCommand;
+import xiamomc.morph.network.multiInstance.protocol.IClientHandler;
+import xiamomc.morph.network.multiInstance.protocol.IMasterHandler;
+
+public abstract class MIC2SCommand<T> extends AbstractC2SCommand<T>
+{
+    protected final Logger logger = MorphPlugin.getInstance().getSLF4JLogger();
+
+    protected final String baseName;
+
+    @Override
+    public final void onCommand(BasicClientHandler<?> handler)
+    {
+    }
+
+    @Override
+    public String getBaseName()
+    {
+        return baseName;
+    }
+
+    public abstract void onCommand(IClientHandler handler);
+
+    public MIC2SCommand(String cmdBaseName, T... arguments)
+    {
+        super(arguments);
+        this.baseName = cmdBaseName;
+    }
+
+
+    @Nullable
+    private WebSocket sourceSocket;
+
+    public void setSourceSocket(@NotNull WebSocket socket)
+    {
+        this.sourceSocket = socket;
+    }
+
+    @Nullable
+    public WebSocket getSocket()
+    {
+        return sourceSocket;
+    }
+}

--- a/src/main/java/xiamomc/morph/network/multiInstance/protocol/c2s/MIC2SDisguiseMetaCommand.java
+++ b/src/main/java/xiamomc/morph/network/multiInstance/protocol/c2s/MIC2SDisguiseMetaCommand.java
@@ -1,0 +1,61 @@
+package xiamomc.morph.network.multiInstance.protocol.c2s;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+import org.jetbrains.annotations.Nullable;
+import xiamomc.morph.MorphPlugin;
+import xiamomc.morph.network.multiInstance.protocol.IClientHandler;
+import xiamomc.morph.network.multiInstance.protocol.IMasterHandler;
+import xiamomc.morph.network.multiInstance.protocol.Operation;
+import xiamomc.morph.network.multiInstance.protocol.SocketDisguiseMeta;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+public class MIC2SDisguiseMetaCommand extends MIC2SCommand<SocketDisguiseMeta>
+{
+    public MIC2SDisguiseMetaCommand(SocketDisguiseMeta meta)
+    {
+        super("dmeta", meta);
+    }
+
+    public MIC2SDisguiseMetaCommand(Operation operation, List<String> identifiers, UUID bindingUUID)
+    {
+        this(new SocketDisguiseMeta(operation, identifiers, bindingUUID));
+    }
+
+    @Nullable
+    public SocketDisguiseMeta getMeta()
+    {
+        return getArgumentAt(0);
+    }
+
+    @Override
+    public void onCommand(IClientHandler handler)
+    {
+        handler.onDisguiseMetaCommand(this);
+    }
+
+    private static final MIC2SDisguiseMetaCommand placeholder = new MIC2SDisguiseMetaCommand(Operation.INVALID, List.of(), UUID.randomUUID());
+
+    public static MIC2SDisguiseMetaCommand from(String text)
+    {
+        var logger = MorphPlugin.getInstance().getSLF4JLogger();
+        try
+        {
+            var gson = new GsonBuilder().disableHtmlEscaping().create();
+
+            var meta = gson.fromJson(text, SocketDisguiseMeta.class);
+            return new MIC2SDisguiseMetaCommand(meta);
+        }
+        catch (Throwable t)
+        {
+            logger.warn("Unable to deserialize list or UUID! Returning placeholder.." + t.getMessage());
+            t.printStackTrace();
+
+            return placeholder;
+        }
+    }
+}

--- a/src/main/java/xiamomc/morph/network/multiInstance/protocol/c2s/MIC2SLoginCommand.java
+++ b/src/main/java/xiamomc/morph/network/multiInstance/protocol/c2s/MIC2SLoginCommand.java
@@ -1,0 +1,69 @@
+package xiamomc.morph.network.multiInstance.protocol.c2s;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import xiamomc.morph.MorphPlugin;
+import xiamomc.morph.network.multiInstance.protocol.IClientHandler;
+import xiamomc.morph.network.multiInstance.protocol.IMasterHandler;
+import xiamomc.morph.network.multiInstance.protocol.ProtocolLevel;
+import xiamomc.morph.network.multiInstance.protocol.s2c.MIS2CCommand;
+
+public class MIC2SLoginCommand extends MIC2SCommand<String>
+{
+    private MIC2SLoginCommand(int ver, String secret)
+    {
+        super("login", "" + ver, secret);
+    }
+
+    public MIC2SLoginCommand(@NotNull ProtocolLevel protocolLevel, @NotNull String secret)
+    {
+        super("login", protocolLevel.versionString(), secret);
+    }
+
+    public int getVersion()
+    {
+        var argRaw = getArgumentAt(0, "0");
+        int version = 0;
+
+        try
+        {
+            version = Integer.parseInt(argRaw);
+        }
+        catch (Throwable t)
+        {
+            logger.warn("Can't get version from arg '%s': %s".formatted(argRaw, t.getMessage()));
+        }
+
+        return version;
+    }
+
+    @Nullable
+    public String getSecret()
+    {
+        return getArgumentAt(1);
+    }
+
+    @Override
+    public void onCommand(IClientHandler handler)
+    {
+        handler.onLoginCommand(this);
+    }
+
+    public static MIC2SLoginCommand from(String arg)
+    {
+        var args = arg.split(" ", 2);
+        int ver = 0;
+
+        try
+        {
+            ver = Integer.parseInt(args[0]);
+        }
+        catch (Throwable t)
+        {
+            var logger = MorphPlugin.getInstance().getSLF4JLogger();
+            logger.warn("Error occurred processing arguments: " + t.getMessage());
+        }
+
+        return new MIC2SLoginCommand(ver, args.length == 2 ? args[1] : "~NULL");
+    }
+}

--- a/src/main/java/xiamomc/morph/network/multiInstance/protocol/s2c/MIS2CCommand.java
+++ b/src/main/java/xiamomc/morph/network/multiInstance/protocol/s2c/MIS2CCommand.java
@@ -1,0 +1,50 @@
+package xiamomc.morph.network.multiInstance.protocol.s2c;
+
+import org.java_websocket.WebSocket;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import xiamomc.morph.MorphPlugin;
+import xiamomc.morph.network.BasicServerHandler;
+import xiamomc.morph.network.commands.S2C.AbstractS2CCommand;
+import xiamomc.morph.network.multiInstance.protocol.IMasterHandler;
+
+public abstract class MIS2CCommand<T> extends AbstractS2CCommand<T>
+{
+    protected final Logger logger = MorphPlugin.getInstance().getSLF4JLogger();
+
+    protected final String baseName;
+
+    @Override
+    public final void onCommand(BasicServerHandler<?> handler)
+    {
+    }
+
+    @Override
+    public String getBaseName()
+    {
+        return baseName;
+    }
+
+    public abstract void onCommand(IMasterHandler handler);
+
+    public MIS2CCommand(String cmdBaseName, T... arguments)
+    {
+        super(arguments);
+        this.baseName = cmdBaseName;
+    }
+
+    @Nullable
+    private WebSocket sourceSocket;
+
+    public void setSourceSocket(@NotNull WebSocket socket)
+    {
+        this.sourceSocket = socket;
+    }
+
+    @Nullable
+    public WebSocket getSocket()
+    {
+        return sourceSocket;
+    }
+}

--- a/src/main/java/xiamomc/morph/network/multiInstance/protocol/s2c/MIS2CDisconnectCommand.java
+++ b/src/main/java/xiamomc/morph/network/multiInstance/protocol/s2c/MIS2CDisconnectCommand.java
@@ -1,0 +1,67 @@
+package xiamomc.morph.network.multiInstance.protocol.s2c;
+
+import xiamomc.morph.MorphPlugin;
+import xiamomc.morph.network.multiInstance.protocol.IMasterHandler;
+import xiamomc.morph.network.server.MorphClientHandler;
+
+public class MIS2CDisconnectCommand extends MIS2CCommand<String>
+{
+    public MIS2CDisconnectCommand(int reasonCode)
+    {
+        this(reasonCode, "<No details>");
+    }
+
+    public MIS2CDisconnectCommand(int reasonCode, String detail)
+    {
+        super("deny", "" + reasonCode, detail);
+    }
+
+    @Override
+    public void onCommand(IMasterHandler handler)
+    {
+        handler.onDisconnectCommand(this);
+    }
+
+    public int getReasonCode()
+    {
+        var str = getArgumentAt(0, "0");
+
+        try
+        {
+            return Integer.parseInt(str);
+        }
+        catch (Throwable t)
+        {
+            logger.warn("Unable to parse integer for deny command: " + t.getMessage());
+        }
+
+        return -2;
+    }
+
+    public String getDetails()
+    {
+        return getArgumentAt(1, "<No details>");
+    }
+
+    public static MIS2CDisconnectCommand from(String text)
+    {
+        var args = text.split(" ", 2);
+        int reasonCode = -2;
+
+        try
+        {
+            reasonCode = Integer.parseInt(args[0]);
+        }
+        catch (Throwable t)
+        {
+            var logger = MorphPlugin.getInstance().getSLF4JLogger();
+
+            logger.warn("Can't parse disconnect reason code from the server command");
+        }
+
+        if (args.length == 2)
+            return new MIS2CDisconnectCommand(reasonCode, args[1]);
+        else
+            return new MIS2CDisconnectCommand(reasonCode);
+    }
+}

--- a/src/main/java/xiamomc/morph/network/multiInstance/protocol/s2c/MIS2CDisguiseMetaCommand.java
+++ b/src/main/java/xiamomc/morph/network/multiInstance/protocol/s2c/MIS2CDisguiseMetaCommand.java
@@ -1,0 +1,51 @@
+package xiamomc.morph.network.multiInstance.protocol.s2c;
+
+import org.jetbrains.annotations.Nullable;
+import xiamomc.morph.MorphPlugin;
+import xiamomc.morph.network.multiInstance.protocol.IMasterHandler;
+import xiamomc.morph.network.multiInstance.protocol.Operation;
+import xiamomc.morph.network.multiInstance.protocol.SocketDisguiseMeta;
+
+import java.util.List;
+import java.util.UUID;
+
+public class MIS2CDisguiseMetaCommand extends MIS2CCommand<SocketDisguiseMeta>
+{
+
+    public MIS2CDisguiseMetaCommand(SocketDisguiseMeta meta)
+    {
+        super("dmeta", meta);
+    }
+
+    public MIS2CDisguiseMetaCommand(Operation operation, List<String> identifiers, UUID bindingUUID)
+    {
+        this(new SocketDisguiseMeta(operation, identifiers, bindingUUID));
+    }
+
+    @Override
+    public void onCommand(IMasterHandler handler)
+    {
+        handler.onDisguiseMetaCommand(this);
+    }
+
+    @Nullable
+    public SocketDisguiseMeta getMeta()
+    {
+        return getArgumentAt(0);
+    }
+
+    public static MIS2CDisguiseMetaCommand from(String text)
+    {
+        try
+        {
+            return new MIS2CDisguiseMetaCommand(gson().fromJson(text, SocketDisguiseMeta.class));
+        }
+        catch (Throwable t)
+        {
+            var logger = MorphPlugin.getInstance().getSLF4JLogger();
+            logger.warn("Failed to parse SocketDisguiseMeta from the server command! Leaving empty...");
+
+            return new MIS2CDisguiseMetaCommand(Operation.INVALID, List.of(), UUID.randomUUID());
+        }
+    }
+}

--- a/src/main/java/xiamomc/morph/network/multiInstance/protocol/s2c/MIS2CLoginResultCommand.java
+++ b/src/main/java/xiamomc/morph/network/multiInstance/protocol/s2c/MIS2CLoginResultCommand.java
@@ -1,0 +1,27 @@
+package xiamomc.morph.network.multiInstance.protocol.s2c;
+
+import xiamomc.morph.network.multiInstance.protocol.IMasterHandler;
+
+public class MIS2CLoginResultCommand extends MIS2CCommand<Boolean>
+{
+    public MIS2CLoginResultCommand(boolean allowed)
+    {
+        super("r_login", allowed);
+    }
+
+    public boolean isAllowed()
+    {
+        return this.getArgumentAt(0, false);
+    }
+
+    @Override
+    public void onCommand(IMasterHandler handler)
+    {
+        handler.onLoginResultCommand(this);
+    }
+
+    public static MIS2CLoginResultCommand from(String text)
+    {
+        return new MIS2CLoginResultCommand(Boolean.parseBoolean(text));
+    }
+}

--- a/src/main/java/xiamomc/morph/network/multiInstance/protocol/s2c/MIS2CStateCommand.java
+++ b/src/main/java/xiamomc/morph/network/multiInstance/protocol/s2c/MIS2CStateCommand.java
@@ -14,13 +14,13 @@ public class MIS2CStateCommand extends MIS2CCommand<String>
     @Override
     public void onCommand(IMasterHandler handler)
     {
+        handler.onStateCommand(this);
     }
 
-    public enum ProtocolState
+    public ProtocolState getState()
     {
-        INVALID,
-        SYNC,
-        PLAY
+        return Arrays.stream(ProtocolState.values()).filter(s -> s.name().equalsIgnoreCase(getArgumentAt(0, "INVALID")))
+                .findFirst().orElse(ProtocolState.INVALID);
     }
 
     public static MIS2CStateCommand from(String text)

--- a/src/main/java/xiamomc/morph/network/multiInstance/protocol/s2c/MIS2CStateCommand.java
+++ b/src/main/java/xiamomc/morph/network/multiInstance/protocol/s2c/MIS2CStateCommand.java
@@ -1,0 +1,33 @@
+package xiamomc.morph.network.multiInstance.protocol.s2c;
+
+import xiamomc.morph.network.multiInstance.protocol.IMasterHandler;
+
+import java.util.Arrays;
+
+public class MIS2CStateCommand extends MIS2CCommand<String>
+{
+    public MIS2CStateCommand(ProtocolState newState)
+    {
+        super("state", newState.name());
+    }
+
+    @Override
+    public void onCommand(IMasterHandler handler)
+    {
+    }
+
+    public enum ProtocolState
+    {
+        INVALID,
+        SYNC,
+        PLAY
+    }
+
+    public static MIS2CStateCommand from(String text)
+    {
+        var match = Arrays.stream(ProtocolState.values()).filter(v -> v.name().equalsIgnoreCase(text))
+                .findFirst().orElse(ProtocolState.INVALID);
+
+        return new MIS2CStateCommand(match);
+    }
+}

--- a/src/main/java/xiamomc/morph/network/multiInstance/protocol/s2c/MIS2CSyncMetaCommand.java
+++ b/src/main/java/xiamomc/morph/network/multiInstance/protocol/s2c/MIS2CSyncMetaCommand.java
@@ -9,15 +9,15 @@ import xiamomc.morph.network.multiInstance.protocol.SocketDisguiseMeta;
 import java.util.List;
 import java.util.UUID;
 
-public class MIS2CDisguiseMetaCommand extends MIS2CCommand<SocketDisguiseMeta>
+public class MIS2CSyncMetaCommand extends MIS2CCommand<SocketDisguiseMeta>
 {
 
-    public MIS2CDisguiseMetaCommand(SocketDisguiseMeta meta)
+    public MIS2CSyncMetaCommand(SocketDisguiseMeta meta)
     {
         super("dmeta", meta);
     }
 
-    public MIS2CDisguiseMetaCommand(Operation operation, List<String> identifiers, UUID bindingUUID)
+    public MIS2CSyncMetaCommand(Operation operation, List<String> identifiers, UUID bindingUUID)
     {
         this(new SocketDisguiseMeta(operation, identifiers, bindingUUID));
     }
@@ -25,7 +25,7 @@ public class MIS2CDisguiseMetaCommand extends MIS2CCommand<SocketDisguiseMeta>
     @Override
     public void onCommand(IMasterHandler handler)
     {
-        handler.onDisguiseMetaCommand(this);
+        handler.onSyncMetaCommand(this);
     }
 
     @Nullable
@@ -34,18 +34,18 @@ public class MIS2CDisguiseMetaCommand extends MIS2CCommand<SocketDisguiseMeta>
         return getArgumentAt(0);
     }
 
-    public static MIS2CDisguiseMetaCommand from(String text)
+    public static MIS2CSyncMetaCommand from(String text)
     {
         try
         {
-            return new MIS2CDisguiseMetaCommand(gson().fromJson(text, SocketDisguiseMeta.class));
+            return new MIS2CSyncMetaCommand(gson().fromJson(text, SocketDisguiseMeta.class));
         }
         catch (Throwable t)
         {
             var logger = MorphPlugin.getInstance().getSLF4JLogger();
             logger.warn("Failed to parse SocketDisguiseMeta from the server command! Leaving empty...");
 
-            return new MIS2CDisguiseMetaCommand(Operation.INVALID, List.of(), UUID.randomUUID());
+            return new MIS2CSyncMetaCommand(Operation.INVALID, List.of(), UUID.randomUUID());
         }
     }
 }

--- a/src/main/java/xiamomc/morph/network/multiInstance/protocol/s2c/ProtocolState.java
+++ b/src/main/java/xiamomc/morph/network/multiInstance/protocol/s2c/ProtocolState.java
@@ -2,9 +2,23 @@ package xiamomc.morph.network.multiInstance.protocol.s2c;
 
 public enum ProtocolState
 {
-    INVALID,
-    LOGIN,
-    SYNC,
-    WAIT_LISTEN
+    INVALID(-3),
+    NOT_CONNECTED(-2),
+    WAITING_LOGIN(-1),
+    LOGIN(0),
+    SYNC(1),
+    WAIT_LISTEN(2);
+
+    private final int stateCode;
+
+    ProtocolState(int stateCode)
+    {
+        this.stateCode = stateCode;
+    }
+
+    public boolean loggedIn()
+    {
+        return this.stateCode > LOGIN.stateCode;
+    }
 }
 

--- a/src/main/java/xiamomc/morph/network/multiInstance/protocol/s2c/ProtocolState.java
+++ b/src/main/java/xiamomc/morph/network/multiInstance/protocol/s2c/ProtocolState.java
@@ -1,0 +1,10 @@
+package xiamomc.morph.network.multiInstance.protocol.s2c;
+
+public enum ProtocolState
+{
+    INVALID,
+    LOGIN,
+    SYNC,
+    WAIT_LISTEN
+}
+

--- a/src/main/java/xiamomc/morph/network/multiInstance/slave/InstanceClient.java
+++ b/src/main/java/xiamomc/morph/network/multiInstance/slave/InstanceClient.java
@@ -76,6 +76,16 @@ public class InstanceClient extends WebSocketClient
     @Override
     public void onError(Exception e)
     {
+        try
+        {
+            masterHandler.onClientError(e, this);
+        }
+        catch (Throwable t)
+        {
+            logger.warn("Error occurred invoking onClientError(): " + t.getMessage());
+            t.printStackTrace();
+        }
+
         if (e instanceof ConnectException)
         {
             logger.info("Can't reach the server, retrying after 5 seconds: " + e.getMessage());

--- a/src/main/java/xiamomc/morph/network/multiInstance/slave/InstanceClient.java
+++ b/src/main/java/xiamomc/morph/network/multiInstance/slave/InstanceClient.java
@@ -50,7 +50,7 @@ public class InstanceClient extends WebSocketClient
     @Override
     public void onMessage(String msg)
     {
-        logger.info("Received server message: " + msg);
+        //logger.info("Received server message: " + msg);
         masterHandler.onText(msg);
     }
 

--- a/src/main/java/xiamomc/morph/network/multiInstance/slave/InstanceClient.java
+++ b/src/main/java/xiamomc/morph/network/multiInstance/slave/InstanceClient.java
@@ -1,0 +1,92 @@
+package xiamomc.morph.network.multiInstance.slave;
+
+import org.java_websocket.client.WebSocketClient;
+import org.java_websocket.handshake.ServerHandshake;
+import org.slf4j.Logger;
+import xiamomc.morph.config.MorphConfigManager;
+import xiamomc.morph.network.multiInstance.protocol.IMasterHandler;
+import xiamomc.pluginbase.Managers.DependencyManager;
+import xiamomc.pluginbase.XiaMoJavaPlugin;
+
+import java.net.ConnectException;
+import java.net.URI;
+
+public class InstanceClient extends WebSocketClient
+{
+    private MorphConfigManager config;
+    private Logger logger;
+
+    private XiaMoJavaPlugin plugin;
+
+    private IMasterHandler masterHandler;
+
+    public InstanceClient(URI serverUri, XiaMoJavaPlugin plugin, IMasterHandler masterHandler)
+    {
+        super(serverUri);
+
+        this.logger = plugin.getSLF4JLogger();
+
+        var dependencies = DependencyManager.getManagerOrCreate(plugin);
+        config = dependencies.get(MorphConfigManager.class, false);
+
+        plugin.schedule(this::load);
+        this.plugin = plugin;
+        this.masterHandler = masterHandler;
+    }
+
+    private void load()
+    {
+    }
+
+    //region WebSocket stuffs
+
+    @Override
+    public void onOpen(ServerHandshake serverHandshake)
+    {
+        logger.info("Opened connection to the instance server.");
+        masterHandler.onConnectionOpen();
+    }
+
+    @Override
+    public void onMessage(String msg)
+    {
+        logger.info("Received server message: " + msg);
+        masterHandler.onText(msg);
+    }
+
+    @Override
+    public void onClose(int code, String reason, boolean isFromRemote)
+    {
+        logger.info("Connection closed with code '%s' and reason '%s'".formatted(code, reason));
+
+        if (code == 1001 || code == 1000)
+        {
+            logger.info("Reconnecting after 10 seconds");
+            plugin.schedule(this::reconnect, 10 * 20);
+        }
+    }
+
+    @Override
+    public void connect()
+    {
+        logger.info("Connecting the instance server...");
+        super.connect();
+    }
+
+    @Override
+    public void onError(Exception e)
+    {
+        if (e instanceof ConnectException)
+        {
+            logger.info("Can't reach the server, retrying after 5 seconds: " + e.getMessage());
+            plugin.schedule(this::reconnect, 5 * 20);
+
+            return;
+        }
+
+        logger.error("Unknown error occurred with the client: " + e.getMessage());
+        e.printStackTrace();
+    }
+
+    //endregion
+}

--- a/src/main/java/xiamomc/morph/network/multiInstance/slave/SlaveInstance.java
+++ b/src/main/java/xiamomc/morph/network/multiInstance/slave/SlaveInstance.java
@@ -1,0 +1,251 @@
+package xiamomc.morph.network.multiInstance.slave;
+
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+import org.bukkit.Bukkit;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Nullable;
+import xiamomc.morph.MorphManager;
+import xiamomc.morph.MorphPluginObject;
+import xiamomc.morph.config.ConfigOption;
+import xiamomc.morph.config.MorphConfigManager;
+import xiamomc.morph.network.ReasonCodes;
+import xiamomc.morph.network.commands.C2S.AbstractC2SCommand;
+import xiamomc.morph.network.commands.CommandRegistries;
+import xiamomc.morph.network.multiInstance.IInstanceService;
+import xiamomc.morph.network.multiInstance.protocol.IMasterHandler;
+import xiamomc.morph.network.multiInstance.protocol.Operation;
+import xiamomc.morph.network.multiInstance.protocol.ProtocolLevel;
+import xiamomc.morph.network.multiInstance.protocol.c2s.MIC2SCommand;
+import xiamomc.morph.network.multiInstance.protocol.c2s.MIC2SDisguiseMetaCommand;
+import xiamomc.morph.network.multiInstance.protocol.c2s.MIC2SLoginCommand;
+import xiamomc.morph.network.multiInstance.protocol.s2c.*;
+import xiamomc.morph.network.server.MorphClientHandler;
+import xiamomc.morph.storage.playerdata.PlayerMeta;
+import xiamomc.pluginbase.Annotations.Initializer;
+import xiamomc.pluginbase.Annotations.Resolved;
+import xiamomc.pluginbase.Bindables.Bindable;
+import xiamomc.pluginbase.Exceptions.NullDependencyException;
+
+import java.net.URI;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+
+public class SlaveInstance extends MorphPluginObject implements IInstanceService, IMasterHandler
+{
+    @Nullable
+    private InstanceClient client;
+
+    private boolean stopClient()
+    {
+        if (client == null) return true;
+
+        try
+        {
+            client.close(ReasonCodes.DISCONNECT);
+            client = null;
+
+            return true;
+        }
+        catch (Throwable t)
+        {
+            logger.warn("Can't close client!");
+            return false;
+        }
+    }
+
+    @Resolved
+    private MorphConfigManager config;
+
+    /**
+     * @return Whether this operation operates successfully
+     */
+    private boolean prepareClient()
+    {
+        if (!stopClient())
+            return false;
+
+        try
+        {
+            var rawAddr = config.getOrDefault(String.class, ConfigOption.MASTER_ADDRESS);
+            var uri = URI.create("ws://" + rawAddr);
+
+            var client = new InstanceClient(uri, plugin, this);
+
+            this.client = client;
+            CompletableFuture.runAsync(client);
+
+            return true;
+        }
+        catch (Throwable t)
+        {
+            logger.warn("Error occurred setting up client: " + t.getMessage());
+            t.printStackTrace();
+
+            return false;
+        }
+    }
+
+    @Initializer
+    private void load()
+    {
+        logger.info("Preparing multi-instance service...");
+
+        config.bind(secret, ConfigOption.MASTER_SECRET);
+
+        registries.registerS2C("deny", MIS2CDisconnectCommand::from)
+                .registerS2C("dmeta", MIS2CDisguiseMetaCommand::from)
+                .registerS2C("r_login", MIS2CLoginResultCommand::from);
+
+        if (!prepareClient())
+        {
+            logger.warn("Can't setup client, this instance will stay offline from the instance network!");
+            return;
+        }
+    }
+
+    private final Bindable<String> secret = new Bindable<>(null);
+
+    @Override
+    public boolean stop()
+    {
+        return stopClient();
+    }
+
+    @Resolved
+    private MorphManager morphManager;
+
+    @Resolved
+    private MorphClientHandler clientHandler;
+
+    @ApiStatus.Internal
+    public void sendCommand(AbstractC2SCommand<?> command)
+    {
+        if (silent)
+            return;
+
+        if (client == null)
+            throw new NullDependencyException("Null client!");
+
+        client.send(command.buildCommand());
+    }
+
+    @Override
+    public void onDisguiseMetaCommand(MIS2CDisguiseMetaCommand metaCommand)
+    {
+        var meta = metaCommand.getMeta();
+        if (meta == null)
+        {
+            logger.warn("Bad server implementation? Get DisguiseMeta command but meta is null!");
+            return;
+        }
+
+        if (!meta.isValid())
+        {
+            logger.warn("Bad server implementation? The meta is invalid!");
+            return;
+        }
+
+        var operation = meta.getOperation();
+        var offlinePlayer = Bukkit.getOfflinePlayer(Objects.requireNonNull(meta.getBindingUuid(), "???"));
+
+        var playerMeta = morphManager.getPlayerMeta(offlinePlayer);
+        var unlocked = playerMeta.getUnlockedDisguises();
+
+        var player = offlinePlayer.getPlayer();
+
+        silent = true;
+
+        if (operation == Operation.ADD_IF_ABSENT)
+        {
+            meta.getIdentifiers().forEach(id ->
+            {
+                var disguiseMeta = morphManager.getDisguiseMeta(id);
+
+                if (!unlocked.contains(disguiseMeta))
+                    playerMeta.addDisguise(disguiseMeta);
+            });
+
+            //morphManager.saveConfiguration();
+
+            if (player != null)
+                clientHandler.refreshPlayerClientMorphs(playerMeta.getUnlockedDisguiseIdentifiers(), player);
+        }
+        else if (operation == Operation.REMOVE)
+        {
+            meta.getIdentifiers().forEach(id ->
+            {
+                var disguiseMeta = morphManager.getDisguiseMeta(id);
+
+                playerMeta.removeDisguise(disguiseMeta);
+            });
+
+            //morphManager.saveConfiguration();
+
+            if (player != null)
+                clientHandler.refreshPlayerClientMorphs(playerMeta.getUnlockedDisguiseIdentifiers(), player);
+        }
+
+        silent = false;
+    }
+
+    @Override
+    public void onDisconnectCommand(MIS2CDisconnectCommand cDenyCommand)
+    {
+        this.stopClient();
+    }
+
+    @Override
+    public void onLoginResultCommand(MIS2CLoginResultCommand cLoginResultCommand)
+    {
+        if (!cLoginResultCommand.isAllowed()) return;
+
+        var cmds = new ObjectArrayList<MIC2SDisguiseMetaCommand>();
+        var disguises = morphManager.listAllPlayerMeta();
+        for (var meta : disguises)
+        {
+            var identifiers = meta.getUnlockedDisguiseIdentifiers();
+
+            if (!identifiers.isEmpty())
+                cmds.add(new MIC2SDisguiseMetaCommand(Operation.ADD_IF_ABSENT, identifiers, meta.uniqueId));
+        }
+
+        cmds.forEach(this::sendCommand);
+    }
+
+    private final ProtocolLevel implementingLevel = ProtocolLevel.V1;
+
+    @Override
+    public void onConnectionOpen()
+    {
+        this.addSchedule(() -> this.sendCommand(new MIC2SLoginCommand(implementingLevel, secret.get())));
+    }
+
+    private final CommandRegistries registries = new CommandRegistries();
+
+    @Override
+    public void onText(String text)
+    {
+        this.addSchedule(() -> onCommandRaw(text));
+    }
+
+    private void onCommandRaw(String raw)
+    {
+        var text = raw.split(" ", 2);
+        var cmd = registries.createS2CCommand(text[0], text.length == 2 ? text[1] : "");
+        if (cmd == null)
+        {
+            logger.warn("Unknown command: " + text[0]);
+            return;
+        }
+
+        if (!(cmd instanceof MIS2CCommand<?> mis2c))
+        {
+            logger.warn("Command is not a MIS2C instance!");
+            return;
+        }
+
+        mis2c.onCommand(this);
+    }
+
+    private boolean silent = false;
+}

--- a/src/main/java/xiamomc/morph/network/multiInstance/slave/SlaveInstance.java
+++ b/src/main/java/xiamomc/morph/network/multiInstance/slave/SlaveInstance.java
@@ -261,6 +261,8 @@ public class SlaveInstance extends MorphPluginObject implements IInstanceService
         for (var socketMeta : revokeStatesAfterDisconnect)
             cmds.add(new MIC2SDisguiseMetaCommand(socketMeta));
 
+        revokeStatesAfterDisconnect.clear();
+
         cmds.forEach(this::sendCommand);
     }
 

--- a/src/main/java/xiamomc/morph/storage/playerdata/PlayerDataStore.java
+++ b/src/main/java/xiamomc/morph/storage/playerdata/PlayerDataStore.java
@@ -249,4 +249,9 @@ public class PlayerDataStore extends MorphJsonBasedStorage<PlayerMetaContainer> 
         else
             player.sendMessage(MessageUtils.prefixes(player, text));
     }
+
+    public List<PlayerMeta> getAll()
+    {
+        return new ObjectArrayList<>(storingObject.playerMetas);
+    }
 }


### PR DESCRIPTION
目前是基于WebSocket的通信，可用于在各个FeatherMorph实例之间同步玩家已解锁的伪装。

## 协议设计

### 连接和登入阶段
1. 客户端向服务端建立连接
2. 建立完成后，客户端向服务端发送包含客户端协议版本和secret的登录请求(`MIC2SLoginCommand`)
3. 服务端验证客户端发来的登录请求
4. 服务端向客户端发送登录结果(`MIS2CLoginResultCommand`)
4.1. 若登录不通过，则服务端会在发送结果后关闭与客户端的连接，登入过程中断
5. 至此，登入阶段完成

### 初始同步阶段
1. 服务端向客户端发送状态指令(`MIS2CStateCommand`)切换到同步状态
    - 尚未设计好同步状态下双方的行为
2. 客户端向服务端发送自己存储的所有变形解锁状态(`MIC2SDisguiseMetaCommand`?)
3. 服务端接收状态，并与自己当前存储的进行合并
4. 服务端向客户端发送自己存储的所有变形解锁状态(`MIS2CDisguiseMetaCommand`?)
5. 客户端接收状态，并合并到自己的存储中。此存储可被转存到文件，也可以保持在内存中
6. 至此，同步阶段完成

### 待机阶段
1. 服务端向客户端发送状态指令(`MIS2CStateCommand`)切换到待机状态
2. 此时客户端监控自己所处服务器的伪装解锁和锁定，并将状态通过`MIC2SDisguiseMetaCommand`汇报给服务端
3. 服务端接收指令，并与自己当前存储的进行合并
4. 服务端将此指令包装为`MIS2CDisguiseMetaCommand`后广播给其他的客户端
5. 其他的客户端在接收到指令后，与自己的存储合并。此存储可被转存到文件，也可以保持在内存中
5.1. 这里可能会触发服务端 <-> 客户端的循环调用，实现时要注意避免客户端在合并服务端指令时再次当作伪装解锁汇报给服务端

### 断开阶段
1. 客户端断开和服务端的连接
2. 服务端检测到断连，并将客户端从已登入的客户端中移除

## 一些设想
- 多实例网络的主实例(`MasterInstance`)应和服务端渲染器一样，与其他组件保持最小接触，使其更多成为独立的组件
- ~~当一个服务器启用主实例时，其应当同时开启一个主实例和一个从实例(`SlaveInstance`)，*其中从实例应当时第一个和主实例建立通信的实例以方便设置初始伪装解锁信息 (1)*~~(2)
    - ~~(1): 可能需要额外实现一套内部通信方法~~
    - (2): 已有其他实现方案

## 问题
- ~~根据设计，如果某一实例在与服务器断开连接后剥夺了此实例下某个玩家的伪装，那么在重新连接后被剥夺的伪装会在同步状态被重新给予此玩家。（断线后的剥夺状态无法在连接后在网络中同步）~~