### PR TITLE
Replace NBT with Disguise Property

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,10 +1,10 @@
 project_version=2.3.5
 
 # FM Protocols
-compat_layer_version=2e128d96ff
+compat_layer_version=2.3.6
 protocols_version=5cdc0ca682
-protocols_use_local_build=false
-protocols_local_version=2.1.1
+protocols_use_local_build=true
+protocols_local_version=2.3.6
 
 mc_version=1.21.8
 minecraft_version=1.21.8-R0.1-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,9 @@
 project_version=2.3.5
 
 # FM Protocols
-compat_layer_version=2.3.6
-protocols_version=5cdc0ca682
-protocols_use_local_build=true
+compat_layer_version=659b728c96
+protocols_version=c6891d2277
+protocols_use_local_build=false
 protocols_local_version=2.3.6
 
 mc_version=1.21.8

--- a/src/main/java/xyz/nifeather/morph/MorphManager.java
+++ b/src/main/java/xyz/nifeather/morph/MorphManager.java
@@ -42,6 +42,8 @@ import xyz.nifeather.morph.misc.disguiseProperty.DisguiseProperties;
 import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
 import xyz.nifeather.morph.misc.disguiseProperty.values.OffTreeProperties;
 import xyz.nifeather.morph.misc.permissions.CommonPermissions;
+import xyz.nifeather.morph.network.Constants;
+import xyz.nifeather.morph.network.commands.S2C.S2CUpdatePropertiesCommand;
 import xyz.nifeather.morph.network.commands.S2C.admin.reveal.S2CRemoveAdminRevealCommand;
 import xyz.nifeather.morph.network.commands.S2C.admin.reveal.S2CSyncAdminRevealCommand;
 import xyz.nifeather.morph.network.commands.S2C.set.*;
@@ -861,9 +863,6 @@ public class MorphManager extends MorphPluginObject implements IManagePlayerData
                     wrapper, provider, equipment,
                     clientHandler.getPlayerOption(player, true), playerMorphConfig);
 
-            if (result.isCopy())
-                outComingState.setSessionData(DATAKEY_SKIP_PROPERTIES, true);
-
             return DisguiseBuildResult.of(outComingState, provider, disguiseMeta, targetEntity);
         }
         catch (IllegalArgumentException iae)
@@ -890,11 +889,6 @@ public class MorphManager extends MorphPluginObject implements IManagePlayerData
         }
     }
 
-    /**
-     * Key that indicates whether a disguise state should have random properties set on build.
-     */
-    public static final String DATAKEY_SKIP_PROPERTIES = "skip_properties_init";
-
     private void buildDisguise(DisguiseBuildResult result,
                                MorphParameters parameters,
                                PlayerMeta playerOptions)
@@ -909,27 +903,16 @@ public class MorphManager extends MorphPluginObject implements IManagePlayerData
         var state = result.state();
         var wrapper = state.getDisguiseWrapper();
 
-        if (!state.getSessionDataOr(DATAKEY_SKIP_PROPERTIES, Boolean.class, false))
-        {
-            // 同步伪装属性
-            var propertyHandler = state.disguisePropertyHandler();
-            var properties = disguiseProperties.get(state.getEntityType());
-            propertyHandler.initProperties(properties);
-            propertyHandler.updateFromPropertiesInput(parameters.properties);
+        // 设定形态属性
+        var propertyHandler = state.disguisePropertyHandler();
+        var properties = disguiseProperties.get(state.getEntityType());
+        propertyHandler.initProperties(properties);
 
-            provider.setupProperties(state, targetEntity);
+        provider.setupProperties(state, targetEntity);
+        propertyHandler.updateFromPropertiesInput(parameters.propertiesInput);
 
-            propertyHandler.getAll().forEach((property, value) ->
-            {
-                wrapper.writeProperty((SingleProperty<Object>) property, value);
-            });
-        }
-
-        // 初始化nbt
-        var initialNbtCompound = provider.getInitialNbtCompound(state, targetEntity, false);
-
-        if (initialNbtCompound != null)
-            state.getDisguiseWrapper().mergeCompound(initialNbtCompound);
+        propertyHandler.getAll().forEach((property, value) ->
+                wrapper.writeProperty((SingleProperty<Object>) property, value));
 
         // 设定显示名称
         if (targetEntity != null && targetEntity.customName() != null)
@@ -1031,14 +1014,14 @@ public class MorphManager extends MorphPluginObject implements IManagePlayerData
         if (provider.validForClient(newState))
         {
             clientHandler.sendCommand(player, new S2CSetSNbtCommand(newState.getCulledNbtString()));
-
-            clientHandler.sendCommand(player, new S2CSetSelfViewIdentifierCommand(provider.getSelfViewIdentifier(newState)));
             provider.getInitialSyncCommands(newState).forEach(s -> clientHandler.sendCommand(player, s));
 
             // 设置Profile
             if (newState.haveProfile())
                 clientHandler.sendCommand(player, new S2CSetProfileCommand(newState.getProfileNbtString()));
         }
+
+        clientHandler.sendCommand(player, new S2CUpdatePropertiesCommand(newState.disguisePropertyHandler().toNetworkProperties()));
 
         // 设置可用动作
         var availableAnimations = provider.getAnimationProvider()
@@ -1164,8 +1147,15 @@ public class MorphManager extends MorphPluginObject implements IManagePlayerData
         var player = state.getPlayer();
 
         clientHandler.updateCurrentIdentifier(player, state.getDisguiseIdentifier());
-        clientHandler.sendCommand(player, new S2CSetSNbtCommand(state.getCulledNbtString()));
-        clientHandler.sendCommand(player, new S2CSetSelfViewIdentifierCommand(state.getProvider().getSelfViewIdentifier(state)));
+
+        var clientSession = clientHandler.getSession(player);
+
+        // For legacy client compat
+        //todo: Remove at 2026, or 1.22 comes out
+        if (clientSession != null && clientSession.apiVersion < Constants.ApiLevel.NETWORK_DISGUISE_PROPERTIES.protocolVersion)
+            clientHandler.sendCommand(player, new S2CSetSNbtCommand(state.getCulledNbtString()));
+
+        clientHandler.sendCommand(player, new S2CUpdatePropertiesCommand(state.disguisePropertyHandler().toNetworkProperties()));
 
         //刷新主动
         state.applyCooldownToClient();
@@ -1305,7 +1295,6 @@ public class MorphManager extends MorphPluginObject implements IManagePlayerData
 
         // 向客户端同步伪装属性
         clientHandler.updateCurrentIdentifier(player, null);
-        clientHandler.sendCommand(player, new S2CSetSelfViewIdentifierCommand(null));
 
         var revLevel = revealingHandler.getRevealingState(player).getBaseValue();
         clientHandler.sendCommand(player, new S2CSetMobRevealCommand(revLevel));

--- a/src/main/java/xyz/nifeather/morph/MorphManager.java
+++ b/src/main/java/xyz/nifeather/morph/MorphManager.java
@@ -934,8 +934,8 @@ public class MorphManager extends MorphPluginObject implements IManagePlayerData
             state.setServerDisplay(serverDisplay);
         }
 
-        provider.onPostConstructDisguise(state, targetEntity);
-        wrapper.onPostConstructDisguise(state, targetEntity);
+        provider.postBuildDisguise(state, targetEntity);
+        wrapper.postBuildDisguise(state, targetEntity);
 
         // 设定初始属性
         var str = uuidRandomBaseString.get()
@@ -1406,7 +1406,7 @@ public class MorphManager extends MorphPluginObject implements IManagePlayerData
     }
 
     @Nullable
-    public DisguiseState getDisguiseStateFor(Entity entity)
+    public DisguiseState getDisguiseStateFor(@Nullable Entity entity)
     {
         if (!(entity instanceof Player player)) return null;
 

--- a/src/main/java/xyz/nifeather/morph/MorphManager.java
+++ b/src/main/java/xyz/nifeather/morph/MorphManager.java
@@ -1013,15 +1013,21 @@ public class MorphManager extends MorphPluginObject implements IManagePlayerData
         // 如果此伪装可以同步给客户端，那么初始化客户端状态
         if (provider.validForClient(newState))
         {
-            clientHandler.sendCommand(player, new S2CSetSNbtCommand(newState.getCulledNbtString()));
+            var clientSession = clientHandler.getSession(player);
+
+            // For legacy client compat
+            //todo: Remove at 2026, or 1.22 comes out
+            if (clientSession != null && clientSession.apiVersion < Constants.ApiLevel.NETWORK_DISGUISE_PROPERTIES.protocolVersion)
+                clientHandler.sendCommand(player, new S2CSetSNbtCommand(newState.getCulledNbtString()));
+            else
+                clientHandler.sendCommand(player, new S2CUpdatePropertiesCommand(newState.disguisePropertyHandler().toNetworkProperties()));
+
             provider.getInitialSyncCommands(newState).forEach(s -> clientHandler.sendCommand(player, s));
 
             // 设置Profile
             if (newState.haveProfile())
                 clientHandler.sendCommand(player, new S2CSetProfileCommand(newState.getProfileNbtString()));
         }
-
-        clientHandler.sendCommand(player, new S2CUpdatePropertiesCommand(newState.disguisePropertyHandler().toNetworkProperties()));
 
         // 设置可用动作
         var availableAnimations = provider.getAnimationProvider()
@@ -1154,8 +1160,8 @@ public class MorphManager extends MorphPluginObject implements IManagePlayerData
         //todo: Remove at 2026, or 1.22 comes out
         if (clientSession != null && clientSession.apiVersion < Constants.ApiLevel.NETWORK_DISGUISE_PROPERTIES.protocolVersion)
             clientHandler.sendCommand(player, new S2CSetSNbtCommand(state.getCulledNbtString()));
-
-        clientHandler.sendCommand(player, new S2CUpdatePropertiesCommand(state.disguisePropertyHandler().toNetworkProperties()));
+        else
+            clientHandler.sendCommand(player, new S2CUpdatePropertiesCommand(state.disguisePropertyHandler().toNetworkProperties()));
 
         //刷新主动
         state.applyCooldownToClient();

--- a/src/main/java/xyz/nifeather/morph/backends/DisguiseBackend.java
+++ b/src/main/java/xyz/nifeather/morph/backends/DisguiseBackend.java
@@ -35,13 +35,6 @@ public abstract class DisguiseBackend<TInstance, TWrapper extends DisguiseWrappe
     }
 
     /**
-     * Creates a disguise from the giving entity
-     * @param targetEntity The entity used to construct disguise
-     * @return A wrapper that handles the constructed disguise
-     */
-    public abstract DisguiseWrapper<TInstance> createInstance(@NotNull Entity targetEntity);
-
-    /**
      * Creates a disguise by the giving type
      * @param entityType Target entity type
      * @return A wrapper that handles the constructed disguise

--- a/src/main/java/xyz/nifeather/morph/backends/DisguiseWrapper.java
+++ b/src/main/java/xyz/nifeather/morph/backends/DisguiseWrapper.java
@@ -282,7 +282,7 @@ public abstract class DisguiseWrapper<TInstance>
      * @param state A {@link DisguiseState} that handles the current wrapper
      * @param targetEntity The targeted entity (If there is any)
      */
-    public abstract void onPostConstructDisguise(DisguiseState state, @Nullable Entity targetEntity);
+    public abstract void postBuildDisguise(DisguiseState state, @Nullable Entity targetEntity);
 
     /**
      * Updates the underlying disguise instance

--- a/src/main/java/xyz/nifeather/morph/backends/DisguiseWrapper.java
+++ b/src/main/java/xyz/nifeather/morph/backends/DisguiseWrapper.java
@@ -2,8 +2,6 @@ package xyz.nifeather.morph.backends;
 
 import com.mojang.authlib.GameProfile;
 import net.minecraft.nbt.CompoundTag;
-import net.minecraft.nbt.Tag;
-import net.minecraft.nbt.TagType;
 import net.minecraft.world.entity.EntityDimensions;
 import net.minecraft.world.phys.AABB;
 import org.bukkit.entity.Entity;
@@ -17,8 +15,10 @@ import org.slf4j.LoggerFactory;
 import xyz.nifeather.morph.FeatherMorphMain;
 import xyz.nifeather.morph.misc.CollisionBoxRecord;
 import xyz.nifeather.morph.misc.DisguiseState;
+import xyz.nifeather.morph.misc.disguiseProperty.DisguiseProperties;
 import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
 import xyz.nifeather.morph.misc.disguiseProperty.values.OffTreeProperties;
+import xyz.nifeather.morph.misc.disguiseProperty.values.SlimeMagmaProperties;
 import xyz.nifeather.morph.utilities.EntityTypeUtils;
 
 import java.util.Map;
@@ -232,7 +232,7 @@ public abstract class DisguiseWrapper<TInstance>
 
         if (getEntityType() != EntityType.SLIME && getEntityType() != EntityType.MAGMA_CUBE) return;
 
-        var dimScale = getSlimeSize();
+        var dimScale = getDimensionScale();
         this.dimensions = EntityDimensions.fixed(0.51F * dimScale, 0.51F * dimScale);
     }
 
@@ -251,9 +251,10 @@ public abstract class DisguiseWrapper<TInstance>
 
     public abstract boolean isBaby();
 
-    protected int getSlimeSize()
+    protected int getDimensionScale()
     {
-        return Math.max(1, getCompound().getInt("Size").orElse(0));
+        var property = DisguiseProperties.INSTANCE.getOrThrow(SlimeMagmaProperties.class);
+        return this.readPropertyOr(property.SIZE, 1);
     }
 
     /**
@@ -291,30 +292,10 @@ public abstract class DisguiseWrapper<TInstance>
     public abstract void update(DisguiseState state, Player player);
 
     /**
-     * Merge NBT to the underlying instance
-     * @param compound {@link CompoundTag}
-     */
-    public abstract void mergeCompound(CompoundTag compound);
-
-    /**
-     * Gets a value from current compound
-     * @param path NBT Path
-     * @param type {@link TagType}, check {@link net.minecraft.nbt.TagTypes} for more information
-     * @return A NBT tag, null if not found
-     */
-    @Nullable
-    public abstract <R extends Tag> R getTag(String path, TagType<R> type);
-
-    /**
      * Returns a copy of the existing compound.
      */
+    @Deprecated
     public abstract CompoundTag getCompound();
-
-    /**
-     * Gets network id of this disguise displayed to other players
-     * @return The network id of this disguise
-     */
-    public abstract int getNetworkEntityId();
 
     /**
      * @return Empty Optional if not available

--- a/src/main/java/xyz/nifeather/morph/backends/client/ModBackend.java
+++ b/src/main/java/xyz/nifeather/morph/backends/client/ModBackend.java
@@ -45,15 +45,6 @@ public class ModBackend extends DisguiseBackend<TrackingClientDisguise, ModDisgu
     }
 
     @Override
-    public DisguiseWrapper<TrackingClientDisguise> createInstance(@NotNull Entity targetEntity)
-    {
-        var wrapper = new ModDisguiseWrapper(new TrackingClientDisguise(targetEntity.getType()), this);
-        wrapper.setDisguiseName(targetEntity.getName());
-
-        return wrapper;
-    }
-
-    @Override
     public DisguiseWrapper<TrackingClientDisguise> createInstance(EntityType entityType)
     {
         return new ModDisguiseWrapper(new TrackingClientDisguise(entityType), this);

--- a/src/main/java/xyz/nifeather/morph/backends/client/ModDisguiseWrapper.java
+++ b/src/main/java/xyz/nifeather/morph/backends/client/ModDisguiseWrapper.java
@@ -3,8 +3,6 @@ package xyz.nifeather.morph.backends.client;
 import com.mojang.authlib.GameProfile;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import net.minecraft.nbt.CompoundTag;
-import net.minecraft.nbt.Tag;
-import net.minecraft.nbt.TagType;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
@@ -47,41 +45,6 @@ public class ModDisguiseWrapper extends EventWrapper<TrackingClientDisguise>
     }
 
     private final ModBackend backend;
-
-    @Override
-    public void mergeCompound(CompoundTag compoundTag)
-    {
-        var compound = readPropertyOr(WrapperProperties.NBT, null);
-
-        if (compound == null)
-        {
-            compound = WrapperProperties.NBT.defaultVal().copy();
-            writeProperty(WrapperProperties.NBT, compound);
-        }
-
-        compound.merge(compoundTag);
-        this.writeProperty(OffTreeProperties.IS_BABY, NbtUtils.isBabyForType(getEntityType(), compound));
-
-        if (this.getEntityType() == EntityType.MAGMA_CUBE || this.getEntityType() == EntityType.SLIME)
-            resetDimensions();
-    }
-
-    @Override
-    public CompoundTag getCompound()
-    {
-        return readPropertyOr(WrapperProperties.NBT, WrapperProperties.NBT.defaultVal().copy());
-    }
-
-    /**
-     * Gets network id of this disguise displayed to other players
-     *
-     * @return The network id of this disguise
-     */
-    @Override
-    public int getNetworkEntityId()
-    {
-        return -1;
-    }
 
     @Override
     public Map<SingleProperty<?>, Object> getProperties()
@@ -129,28 +92,6 @@ public class ModDisguiseWrapper extends EventWrapper<TrackingClientDisguise>
     public <X> X readPropertyOrThrow(SingleProperty<X> property)
     {
         return this.instance.readPropertyOrThrow(property);
-    }
-
-    @Nullable
-    @Override
-    public <R extends Tag> R getTag(@NotNull String path, TagType<R> type)
-    {
-        try
-        {
-            var obj = getCompound().get(path);
-
-            if (obj != null && obj.getType().equals(type))
-                return (R) obj;
-
-            return null;
-        }
-        catch (Throwable t)
-        {
-            logger.error("Unable to read NBT '%s' from instance:".formatted(path));
-            t.printStackTrace();
-
-            return null;
-        }
     }
 
     private static final Logger logger = FeatherMorphMain.getInstance().getSLF4JLogger();
@@ -218,6 +159,12 @@ public class ModDisguiseWrapper extends EventWrapper<TrackingClientDisguise>
     @Override
     public void update(DisguiseState state, Player player)
     {
+    }
+
+    @Override
+    public CompoundTag getCompound()
+    {
+        return new CompoundTag();
     }
 
     @Nullable

--- a/src/main/java/xyz/nifeather/morph/backends/client/ModDisguiseWrapper.java
+++ b/src/main/java/xyz/nifeather/morph/backends/client/ModDisguiseWrapper.java
@@ -152,7 +152,7 @@ public class ModDisguiseWrapper extends EventWrapper<TrackingClientDisguise>
     }
 
     @Override
-    public void onPostConstructDisguise(DisguiseState state, @Nullable Entity targetEntity)
+    public void postBuildDisguise(DisguiseState state, @Nullable Entity targetEntity)
     {
     }
 

--- a/src/main/java/xyz/nifeather/morph/backends/server/ServerBackend.java
+++ b/src/main/java/xyz/nifeather/morph/backends/server/ServerBackend.java
@@ -277,8 +277,6 @@ public class ServerBackend extends DisguiseBackend<ServerDisguise, ServerDisguis
         var snbt = spilt[1];
         var typeId = spilt[0];
 
-        CompoundTag compoundTag;
-
         var typeMatch = Arrays.stream(EntityType.values()).filter(
                 t -> t != EntityType.UNKNOWN && t.getKey().asString().equals(typeId)
         ).findFirst().orElse(null);
@@ -289,22 +287,9 @@ public class ServerBackend extends DisguiseBackend<ServerDisguise, ServerDisguis
             return null;
         }
 
-        try
-        {
-            compoundTag = NbtUtils.toCompoundTag(snbt);
-        }
-        catch (Throwable t)
-        {
-            logger.error("Unable to parse sNBT: " + t.getMessage());
-            logger.error("Raw string: '%s'".formatted(snbt));
-            return null;
-        }
-
         var instance = new ServerDisguise(typeMatch);
-        var wrapper = new ServerDisguiseWrapper(instance, this);
-        wrapper.mergeCompound(compoundTag);
 
-        return wrapper;
+        return new ServerDisguiseWrapper(instance, this);
     }
 
     /**
@@ -320,10 +305,8 @@ public class ServerBackend extends DisguiseBackend<ServerDisguise, ServerDisguis
         if (!(wrapper instanceof ServerDisguiseWrapper serverWrapper))
             return null;
 
-        var compound = serverWrapper.getCompound();
-        var nbtStr = NbtUtils.getCompoundString(compound);
         var type = wrapper.getEntityType().getKey().asString();
-        return "%s@%s".formatted(type, nbtStr);
+        return "%s@%s".formatted(type, "NIL");
     }
 
     @Override

--- a/src/main/java/xyz/nifeather/morph/backends/server/ServerBackend.java
+++ b/src/main/java/xyz/nifeather/morph/backends/server/ServerBackend.java
@@ -1,7 +1,6 @@
 package xyz.nifeather.morph.backends.server;
 
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
-import net.minecraft.nbt.CompoundTag;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
@@ -12,7 +11,6 @@ import xyz.nifeather.morph.backends.DisguiseWrapper;
 import xyz.nifeather.morph.backends.server.renderer.ServerRenderer;
 import xyz.nifeather.morph.backends.server.renderer.utilties.WatcherUtils;
 import xyz.nifeather.morph.messages.BackendStrings;
-import xyz.nifeather.morph.utilities.NbtUtils;
 
 import javax.annotation.Nullable;
 import java.util.Arrays;
@@ -59,22 +57,6 @@ public class ServerBackend extends DisguiseBackend<ServerDisguise, ServerDisguis
     public FormattableMessage getDisplayName()
     {
         return BackendStrings.serverBackendName();
-    }
-
-    /**
-     * Creates a disguise from the giving entity
-     *
-     * @param targetEntity The entity used to construct disguise
-     * @return A wrapper that handles the constructed disguise
-     */
-    @Override
-    public DisguiseWrapper<ServerDisguise> createInstance(@NotNull Entity targetEntity)
-    {
-        var wrapper = new ServerDisguiseWrapper(new ServerDisguise(targetEntity.getType()), this);
-        if (targetEntity instanceof Player player)
-            wrapper.setDisguiseName(player.getName());
-
-        return wrapper;
     }
 
     /**

--- a/src/main/java/xyz/nifeather/morph/backends/server/ServerDisguise.java
+++ b/src/main/java/xyz/nifeather/morph/backends/server/ServerDisguise.java
@@ -1,7 +1,6 @@
 package xyz.nifeather.morph.backends.server;
 
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
-import net.minecraft.nbt.CompoundTag;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.EntityType;
 import org.jetbrains.annotations.Nullable;
@@ -26,8 +25,6 @@ public class ServerDisguise implements Cloneable
     public ChatColor glowingColor = ChatColor.WHITE;
 
     public final Map<String, Object> customData = new Object2ObjectOpenHashMap<>();
-
-    public final CompoundTag compoundTag = new CompoundTag();
 
     public boolean isBaby;
 
@@ -60,8 +57,6 @@ public class ServerDisguise implements Cloneable
         obj.type = this.type;
         obj.name = this.name;
         obj.glowingColor = this.glowingColor;
-
-        obj.compoundTag.merge(this.compoundTag);
 
         obj.customData.putAll(this.customData);
 

--- a/src/main/java/xyz/nifeather/morph/backends/server/ServerDisguiseWrapper.java
+++ b/src/main/java/xyz/nifeather/morph/backends/server/ServerDisguiseWrapper.java
@@ -3,8 +3,6 @@ package xyz.nifeather.morph.backends.server;
 import com.mojang.authlib.GameProfile;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import net.minecraft.nbt.CompoundTag;
-import net.minecraft.nbt.Tag;
-import net.minecraft.nbt.TagType;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
@@ -28,7 +26,6 @@ import xyz.nifeather.morph.misc.DisguiseEquipment;
 import xyz.nifeather.morph.misc.DisguiseState;
 import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
 import xyz.nifeather.morph.misc.disguiseProperty.values.OffTreeProperties;
-import xyz.nifeather.morph.utilities.NbtUtils;
 
 import java.util.Map;
 import java.util.Objects;
@@ -49,52 +46,14 @@ public class ServerDisguiseWrapper extends EventWrapper<ServerDisguise>
     }
 
     @Override
-    public void mergeCompound(CompoundTag compoundTag)
+    public CompoundTag getCompound()
     {
-        this.instance.compoundTag.merge(compoundTag);
-        this.instance.isBaby = NbtUtils.isBabyForType(getEntityType(), compoundTag);
-
-        if (this.getEntityType() == EntityType.MAGMA_CUBE || this.getEntityType() == EntityType.SLIME)
-            resetDimensions();
+        var tagCopy = new CompoundTag();
 
         if (bindingWatcher != null)
-        {
-            bindingWatcher.mergeFromCompound(compoundTag);
-
-            if (bindingWatcher instanceof AgeableMobWatcher)
-                bindingWatcher.writePersistent(ValueIndex.AGEABLE_MOB.IS_BABY, instance.isBaby);
-
-            if (compoundTag.contains("Small")) instance.armorStandSmall = compoundTag.getBoolean("Small").orElse(false);
-            if (compoundTag.contains("NoBasePlate")) instance.armorStandNoBasePlate = compoundTag.getBoolean("NoBasePlate").orElse(false);
-            if (compoundTag.contains("ShowArms")) instance.armorStandShowArms = compoundTag.getBoolean("ShowArms").orElse(false);
-        }
-    }
-
-    private CompoundTag getCompound(boolean includeWatcher)
-    {
-        var tagCopy = this.instance.compoundTag.copy();
-
-        if (bindingWatcher != null && includeWatcher)
             tagCopy.merge(WatcherUtils.buildCompoundFromWatcher(bindingWatcher));
 
         return tagCopy;
-    }
-
-    @Override
-    public CompoundTag getCompound()
-    {
-        return this.getCompound(true);
-    }
-
-    /**
-     * Gets network id of this disguise displayed to other players
-     *
-     * @return The network id of this disguise
-     */
-    @Override
-    public int getNetworkEntityId()
-    {
-        return bindingPlayer.getEntityId();
     }
 
     @Override
@@ -102,28 +61,6 @@ public class ServerDisguiseWrapper extends EventWrapper<ServerDisguise>
     {
         var uuid = bindingWatcher == null ? null : bindingWatcher.readEntryOrThrow(CustomEntries.SPAWN_UUID);
         return Objects.requireNonNull(uuid, "VirtualEntityUUID is not set for an instance of ServerDisguiseWrapper");
-    }
-
-    @Nullable
-    @Override
-    public <R extends Tag> R getTag(@NotNull String path, TagType<R> type)
-    {
-        try
-        {
-            var obj = instance.compoundTag.get(path);
-
-            if (obj != null && obj.getType().equals(type))
-                return (R) obj;
-
-            return null;
-        }
-        catch (Throwable t)
-        {
-            logger.error("Unable to read NBT '%s' from instance:".formatted(path));
-            t.printStackTrace();
-
-            return null;
-        }
     }
 
     private static final Logger logger = FeatherMorphMain.getInstance().getSLF4JLogger();
@@ -166,7 +103,7 @@ public class ServerDisguiseWrapper extends EventWrapper<ServerDisguise>
     {
         var newInstance = cloneFromExternal(this, (ServerBackend) getBackend());
 
-        newInstance.mergeCompound(this.getCompound());
+        newInstance.disguiseProperties.putAll(this.disguiseProperties);
         newInstance.writeProperty(OffTreeProperties.FAKE_EQUIPMENT, this.readPropertyOrThrow(OffTreeProperties.FAKE_EQUIPMENT));
 
         return newInstance;
@@ -231,7 +168,10 @@ public class ServerDisguiseWrapper extends EventWrapper<ServerDisguise>
     @Override
     public boolean isBaby()
     {
-        return instance.isBaby;
+        if (!(bindingWatcher instanceof AgeableMobWatcher))
+            return false;
+
+        return bindingWatcher.readOr(ValueIndex.AGEABLE_MOB.IS_BABY, false);
     }
 
     @Override
@@ -309,9 +249,6 @@ public class ServerDisguiseWrapper extends EventWrapper<ServerDisguise>
 
     private void refreshRegistry(@NotNull Player bindingPlayer, @NotNull SingleWatcher bindingWatcher)
     {
-        //和watcher同步我们的NBT
-        bindingWatcher.mergeFromCompound(getCompound(false));
-
         this.disguiseProperties.forEach((property, value) ->
         {
             bindingWatcher.writeProperty((SingleProperty<Object>) property, value);

--- a/src/main/java/xyz/nifeather/morph/backends/server/ServerDisguiseWrapper.java
+++ b/src/main/java/xyz/nifeather/morph/backends/server/ServerDisguiseWrapper.java
@@ -188,7 +188,7 @@ public class ServerDisguiseWrapper extends EventWrapper<ServerDisguise>
     }
 
     @Override
-    public void onPostConstructDisguise(DisguiseState state, @Nullable Entity targetEntity)
+    public void postBuildDisguise(DisguiseState state, @Nullable Entity targetEntity)
     {
     }
 

--- a/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/SingleWatcher.java
+++ b/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/SingleWatcher.java
@@ -486,10 +486,8 @@ public abstract class SingleWatcher extends MorphPluginObject
     {
     }
 
-    public void mergeFromCompound(CompoundTag nbt)
-    {
-    }
-
+    // Kept for legacy client usage
+    //@Deprecated(forRemoval = true)
     public void writeToCompound(CompoundTag nbt)
     {
     }

--- a/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/ArmorStandWatcher.java
+++ b/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/ArmorStandWatcher.java
@@ -1,6 +1,7 @@
 package xyz.nifeather.morph.backends.server.renderer.network.datawatcher.watchers.types;
 
 import com.github.retrooper.packetevents.util.Vector3f;
+import io.papermc.paper.math.Rotations;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.FloatTag;
 import net.minecraft.nbt.ListTag;
@@ -97,41 +98,46 @@ public class ArmorStandWatcher extends InventoryLivingWatcher
 
         if (property.equals(properties.HEAD_ROTATION))
         {
-            var val = (Vector3f) value;
-            this.writePersistent(ValueIndex.ARMOR_STAND.HEAD_ROTATION, val);
+            var val = (Rotations) value;
+            this.writePersistent(ValueIndex.ARMOR_STAND.HEAD_ROTATION, toVector(val));
         }
 
         if (property.equals(properties.BODY_ROTATION))
         {
-            var val = (Vector3f) value;
-            this.writePersistent(ValueIndex.ARMOR_STAND.BODY_ROTATION, val);
+            var val = (Rotations) value;
+            this.writePersistent(ValueIndex.ARMOR_STAND.BODY_ROTATION, toVector(val));
         }
 
         if (property.equals(properties.LEFT_ARM_ROTATION))
         {
-            var val = (Vector3f) value;
-            this.writePersistent(ValueIndex.ARMOR_STAND.LEFT_ARM_ROTATION, val);
+            var val = (Rotations) value;
+            this.writePersistent(ValueIndex.ARMOR_STAND.LEFT_ARM_ROTATION, toVector(val));
         }
 
         if (property.equals(properties.RIGHT_ARM_ROTATION))
         {
-            var val = (Vector3f) value;
-            this.writePersistent(ValueIndex.ARMOR_STAND.RIGHT_ARM_ROTATION, val);
+            var val = (Rotations) value;
+            this.writePersistent(ValueIndex.ARMOR_STAND.RIGHT_ARM_ROTATION, toVector(val));
         }
 
         if (property.equals(properties.LEFT_LEG_ROTATION))
         {
-            var val = (Vector3f) value;
-            this.writePersistent(ValueIndex.ARMOR_STAND.LEFT_LEG_ROTATION, val);
+            var val = (Rotations) value;
+            this.writePersistent(ValueIndex.ARMOR_STAND.LEFT_LEG_ROTATION, toVector(val));
         }
 
         if (property.equals(properties.RIGHT_LEG_ROTATION))
         {
-            var val = (Vector3f) value;
-            this.writePersistent(ValueIndex.ARMOR_STAND.RIGHT_LEG_ROTATION, val);
+            var val = (Rotations) value;
+            this.writePersistent(ValueIndex.ARMOR_STAND.RIGHT_LEG_ROTATION, toVector(val));
         }
 
         super.onPropertyWrite(property, value);
+    }
+
+    private Vector3f toVector(Rotations rotations)
+    {
+        return new Vector3f((float) rotations.x(), (float) rotations.y(), (float) rotations.z());
     }
 
     private ListTag saveRotationOf(SingleValue<Vector3f> sv)

--- a/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/ArmorStandWatcher.java
+++ b/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/ArmorStandWatcher.java
@@ -78,78 +78,60 @@ public class ArmorStandWatcher extends InventoryLivingWatcher
         {
             var val = (Boolean) value;
             this.writePersistent(ValueIndex.ARMOR_STAND.DATA_FLAGS, getArmorStandFlags(this.isSmall(), val, this.noBasePlate()));
+            return;
+        }
+
+        if (property.equals(properties.HAS_BASE_PLATE))
+        {
+            var val = (Boolean) value;
+            this.writePersistent(ValueIndex.ARMOR_STAND.DATA_FLAGS, getArmorStandFlags(this.isSmall(), this.showArms(), val));
+            return;
+        }
+
+        if (property.equals(properties.SMALL))
+        {
+            var val = (Boolean) value;
+            this.writePersistent(ValueIndex.ARMOR_STAND.DATA_FLAGS, getArmorStandFlags(val, this.showArms(), this.noBasePlate()));
+            return;
+        }
+
+        if (property.equals(properties.HEAD_ROTATION))
+        {
+            var val = (Vector3f) value;
+            this.writePersistent(ValueIndex.ARMOR_STAND.HEAD_ROTATION, val);
+        }
+
+        if (property.equals(properties.BODY_ROTATION))
+        {
+            var val = (Vector3f) value;
+            this.writePersistent(ValueIndex.ARMOR_STAND.BODY_ROTATION, val);
+        }
+
+        if (property.equals(properties.LEFT_ARM_ROTATION))
+        {
+            var val = (Vector3f) value;
+            this.writePersistent(ValueIndex.ARMOR_STAND.LEFT_ARM_ROTATION, val);
+        }
+
+        if (property.equals(properties.RIGHT_ARM_ROTATION))
+        {
+            var val = (Vector3f) value;
+            this.writePersistent(ValueIndex.ARMOR_STAND.RIGHT_ARM_ROTATION, val);
+        }
+
+        if (property.equals(properties.LEFT_LEG_ROTATION))
+        {
+            var val = (Vector3f) value;
+            this.writePersistent(ValueIndex.ARMOR_STAND.LEFT_LEG_ROTATION, val);
+        }
+
+        if (property.equals(properties.RIGHT_LEG_ROTATION))
+        {
+            var val = (Vector3f) value;
+            this.writePersistent(ValueIndex.ARMOR_STAND.RIGHT_LEG_ROTATION, val);
         }
 
         super.onPropertyWrite(property, value);
-    }
-
-    @Override
-    public void mergeFromCompound(CompoundTag nbt)
-    {
-        super.mergeFromCompound(nbt);
-        boolean small = isSmall();
-        boolean noBasePlate = noBasePlate();
-        boolean showArms = showArms();
-
-        if (nbt.contains("Small"))
-            small = nbt.getBoolean("Small").orElseThrow();
-
-        if (nbt.contains("NoBasePlate"))
-            noBasePlate = nbt.getBoolean("NoBasePlate").orElseThrow();
-
-        if (nbt.contains("ShowArms"))
-            showArms = nbt.getBoolean("ShowArms").orElseThrow();
-
-        //Tag "Invisible" is not supported as it's synced with the player
-
-        writePersistent(ValueIndex.ARMOR_STAND.DATA_FLAGS, getArmorStandFlags(small, showArms, noBasePlate));
-
-        if (nbt.contains("Pose"))
-        {
-            var poseCompound = nbt.getCompound("Pose").orElseThrow();
-
-            if (poseCompound.contains("Body"))
-            {
-                writePersistent(ValueIndex.ARMOR_STAND.BODY_ROTATION,
-                        getVec3(poseCompound.getListOrEmpty("Body"),
-                                ValueIndex.ARMOR_STAND.BODY_ROTATION.defaultValue()));
-            }
-
-            if (poseCompound.contains("Head"))
-            {
-                writePersistent(ValueIndex.ARMOR_STAND.HEAD_ROTATION,
-                        getVec3(poseCompound.getListOrEmpty("Head"),
-                                ValueIndex.ARMOR_STAND.HEAD_ROTATION.defaultValue()));
-            }
-
-            if (poseCompound.contains("LeftArm"))
-            {
-                writePersistent(ValueIndex.ARMOR_STAND.LEFT_ARM_ROTATION,
-                        getVec3(poseCompound.getListOrEmpty("LeftArm"),
-                                ValueIndex.ARMOR_STAND.LEFT_ARM_ROTATION.defaultValue()));
-            }
-
-            if (poseCompound.contains("RightArm"))
-            {
-                writePersistent(ValueIndex.ARMOR_STAND.RIGHT_ARM_ROTATION,
-                        getVec3(poseCompound.getListOrEmpty("RightArm"),
-                                ValueIndex.ARMOR_STAND.RIGHT_ARM_ROTATION.defaultValue()));
-            }
-
-            if (poseCompound.contains("LeftLeg"))
-            {
-                writePersistent(ValueIndex.ARMOR_STAND.LEFT_LEG_ROTATION,
-                        getVec3(poseCompound.getListOrEmpty("LeftLeg"),
-                                ValueIndex.ARMOR_STAND.LEFT_LEG_ROTATION.defaultValue()));
-            }
-
-            if (poseCompound.contains("RightLeg"))
-            {
-                writePersistent(ValueIndex.ARMOR_STAND.RIGHT_LEG_ROTATION,
-                        getVec3(poseCompound.getListOrEmpty("RightLeg"),
-                                ValueIndex.ARMOR_STAND.RIGHT_LEG_ROTATION.defaultValue()));
-            }
-        }
     }
 
     private ListTag saveRotationOf(SingleValue<Vector3f> sv)

--- a/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/ArmorStandWatcher.java
+++ b/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/ArmorStandWatcher.java
@@ -84,7 +84,7 @@ public class ArmorStandWatcher extends InventoryLivingWatcher
         if (property.equals(properties.HAS_BASE_PLATE))
         {
             var val = (Boolean) value;
-            this.writePersistent(ValueIndex.ARMOR_STAND.DATA_FLAGS, getArmorStandFlags(this.isSmall(), this.showArms(), val));
+            this.writePersistent(ValueIndex.ARMOR_STAND.DATA_FLAGS, getArmorStandFlags(this.isSmall(), this.showArms(), !val));
             return;
         }
 

--- a/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/AxolotlWatcher.java
+++ b/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/AxolotlWatcher.java
@@ -39,18 +39,6 @@ public class AxolotlWatcher extends LivingEntityWatcher
     }
 
     @Override
-    public void mergeFromCompound(CompoundTag nbt)
-    {
-        super.mergeFromCompound(nbt);
-
-        if (nbt.contains("Variant"))
-            writePersistent(ValueIndex.AXOLOTL.COLOR, nbt.getInt("Variant").orElseThrow());
-
-        if (nbt.contains("FromBucket"))
-            writePersistent(ValueIndex.AXOLOTL.SPAWNED_FROM_BUCKET, nbt.getBoolean("FromBucket").orElseThrow());
-    }
-
-    @Override
     public void writeToCompound(CompoundTag nbt)
     {
         super.writeToCompound(nbt);

--- a/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/CatWatcher.java
+++ b/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/CatWatcher.java
@@ -15,6 +15,8 @@ import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
 import xyz.nifeather.morph.misc.disguiseProperty.values.CatProperties;
 
 import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
 
 public class CatWatcher extends TameableAnimalWatcher
 {
@@ -47,6 +49,11 @@ public class CatWatcher extends TameableAnimalWatcher
             var variant = (Cat.Type) value;
             writePersistent(ValueIndex.CAT.CAT_VARIANT, getCatVariant(variant.key().asString()));
         }
+        else if (property.equals(properties.OWNER))
+        {
+            var uuid = (UUID) value;
+            writePersistent(ValueIndex.CAT.OWNER, Optional.ofNullable(uuid));
+        }
 
         super.onPropertyWrite(property, value);
     }
@@ -74,21 +81,6 @@ public class CatWatcher extends TameableAnimalWatcher
                 }
             }
         }
-    }
-
-    @Override
-    public void mergeFromCompound(CompoundTag nbt)
-    {
-        super.mergeFromCompound(nbt);
-
-        if (nbt.contains("variant"))
-        {
-            var name = nbt.getString("variant").orElseThrow();
-            this.writePersistent(ValueIndex.CAT.CAT_VARIANT, getCatVariant(name));
-        }
-
-        if (nbt.contains("CollarColor"))
-            writePersistent(ValueIndex.CAT.COLLAR_COLOR, (int)nbt.getByte("CollarColor").orElseThrow());
     }
 
     @Override

--- a/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/ChickenWatcher.java
+++ b/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/ChickenWatcher.java
@@ -3,7 +3,6 @@ package xyz.nifeather.morph.backends.server.renderer.network.datawatcher.watcher
 import com.github.retrooper.packetevents.protocol.entity.chicken.ChickenVariant;
 import com.github.retrooper.packetevents.protocol.entity.chicken.ChickenVariants;
 import net.minecraft.nbt.CompoundTag;
-import org.bukkit.NamespacedKey;
 import org.bukkit.entity.Chicken;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
@@ -50,23 +49,6 @@ public class ChickenWatcher extends AgeableMobWatcher
         }
 
         super.onPropertyWrite(property, value);
-    }
-
-    @Override
-    public void mergeFromCompound(CompoundTag nbt)
-    {
-        if (nbt.contains("variant"))
-        {
-            var idString = nbt.getString("variant").orElseThrow();
-            var idKey = NamespacedKey.fromString(idString);
-
-            if (idKey == null)
-                return;
-
-            writePersistent(ValueIndex.CHICKEN.CHICKEN_VARIANT, getChickenVariant(idString));
-        }
-
-        super.mergeFromCompound(nbt);
     }
 
     @Override

--- a/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/CowWatcher.java
+++ b/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/CowWatcher.java
@@ -2,7 +2,6 @@ package xyz.nifeather.morph.backends.server.renderer.network.datawatcher.watcher
 
 import com.github.retrooper.packetevents.protocol.entity.cow.CowVariants;
 import net.minecraft.nbt.CompoundTag;
-import org.bukkit.NamespacedKey;
 import org.bukkit.entity.Cow;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
@@ -45,26 +44,6 @@ public class CowWatcher extends AgeableMobWatcher
         }
 
         super.onPropertyWrite(property, value);
-    }
-
-    @Override
-    public void mergeFromCompound(CompoundTag nbt)
-    {
-        if (nbt.contains("variant"))
-        {
-            var idString = nbt.getString("variant").orElseThrow();
-            var idKey = NamespacedKey.fromString(idString);
-
-            if (idKey == null)
-                return;
-
-            var variant = Objects.requireNonNull(CowVariants.getRegistry().getByName(idString),
-                    "No packet version for NMS variant %s!".formatted(idString));
-
-            writePersistent(ValueIndex.COW.COW_VARIANT, variant);
-        }
-
-        super.mergeFromCompound(nbt);
     }
 
     @Override

--- a/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/CreeperWatcher.java
+++ b/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/CreeperWatcher.java
@@ -54,15 +54,6 @@ public class CreeperWatcher extends LivingEntityWatcher
     }
 
     @Override
-    public void mergeFromCompound(CompoundTag nbt)
-    {
-        super.mergeFromCompound(nbt);
-
-        if (nbt.contains("powered"))
-            this.writePersistent(ValueIndex.CREEPER.IS_CHARGED_CREEPER, nbt.getBoolean("powered").orElseThrow());
-    }
-
-    @Override
     public void writeToCompound(CompoundTag nbt)
     {
         super.writeToCompound(nbt);

--- a/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/EnderDragonWatcher.java
+++ b/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/EnderDragonWatcher.java
@@ -50,15 +50,6 @@ public class EnderDragonWatcher extends LivingEntityWatcher
     }
 
     @Override
-    public void mergeFromCompound(CompoundTag nbt)
-    {
-        if (nbt.contains("DragonPhase"))
-            this.writePersistent(ValueIndex.ENDER_DRAGON.DRAGON_PHASE, nbt.getInt("DragonPhase").orElseThrow());
-
-        super.mergeFromCompound(nbt);
-    }
-
-    @Override
     public <X> @Nullable X readEntry(CustomEntry<X> entry)
     {
         if (Objects.equals(entry, CustomEntries.OVERLAYED_YAW))

--- a/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/EntityWatcher.java
+++ b/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/EntityWatcher.java
@@ -228,38 +228,9 @@ public class EntityWatcher extends SingleWatcher
     }
 
     @Override
-    public void mergeFromCompound(CompoundTag nbt)
-    {
-        super.mergeFromCompound(nbt);
-
-        if (nbt.contains("CustomName"))
-        {
-            var name = nbt.getString("CustomName").orElseThrow();
-
-            try
-            {
-                var component = JSONComponentSerializer.json().deserialize(name);
-
-                writePersistent(ValueIndex.BASE_ENTITY.CUSTOM_NAME, Optional.of(component));
-            }
-            catch (Throwable t)
-            {
-                logger.error("Unable to parse CustomName '%s': %s".formatted(name, t.getMessage()));
-            }
-        }
-
-        if (nbt.contains("CustomNameVisible"))
-        {
-            var visible = nbt.getBoolean("CustomNameVisible").orElseThrow();
-            writePersistent(ValueIndex.BASE_ENTITY.CUSTOM_NAME_VISIBLE, visible);
-        }
-    }
-
-    @Override
+    //@Deprecated(forRemoval = true)
     public void writeToCompound(CompoundTag nbt)
     {
-        super.writeToCompound(nbt);
-
         var customName = read(ValueIndex.BASE_ENTITY.CUSTOM_NAME);
         customName.ifPresent(c -> nbt.putString("CustomName", JSONComponentSerializer.json().serialize(c)));
 

--- a/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/FoxWatcher.java
+++ b/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/FoxWatcher.java
@@ -61,18 +61,6 @@ public class FoxWatcher extends AgeableMobWatcher
     }
 
     @Override
-    public void mergeFromCompound(CompoundTag nbt)
-    {
-        super.mergeFromCompound(nbt);
-
-        if (nbt.contains("Type"))
-        {
-            var isSnow = nbt.getString("Type").orElseThrow().equalsIgnoreCase("SNOW");
-            writePersistent(ValueIndex.FOX.FOX_VARIANT, isSnow ? 1 : 0);
-        }
-    }
-
-    @Override
     public void writeToCompound(CompoundTag nbt)
     {
         super.writeToCompound(nbt);

--- a/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/FrogWatcher.java
+++ b/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/FrogWatcher.java
@@ -43,21 +43,6 @@ public class FrogWatcher extends LivingEntityWatcher
     }
 
     @Override
-    public void mergeFromCompound(CompoundTag nbt)
-    {
-        super.mergeFromCompound(nbt);
-
-        if (nbt.contains("variant"))
-        {
-            var typeString = nbt.getString("variant").orElseThrow();
-            NamespacedKey key = NamespacedKey.fromString(typeString);
-
-            if (key != null)
-                writePersistent(ValueIndex.FROG.FROG_VARIANT, getFrogVariant(key));
-        }
-    }
-
-    @Override
     protected <X> void onPropertyWrite(SingleProperty<X> property, X value)
     {
         var properties = DisguiseProperties.INSTANCE.getOrThrow(FrogProperties.class);

--- a/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/GoatWatcher.java
+++ b/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/GoatWatcher.java
@@ -38,21 +38,6 @@ public class GoatWatcher extends LivingEntityWatcher
     }
 
     @Override
-    public void mergeFromCompound(CompoundTag nbt)
-    {
-        super.mergeFromCompound(nbt);
-
-        if (nbt.contains("HasLeftHorn"))
-            writePersistent(ValueIndex.GOAT.HAS_LEFT_HORN, nbt.getBoolean("HasLeftHorn").orElseThrow());
-
-        if (nbt.contains("HasRightHorn"))
-            writePersistent(ValueIndex.GOAT.HAS_RIGHT_HORN, nbt.getBoolean("HasRightHorn").orElseThrow());
-
-        if (nbt.contains("IsScreamingGoat"))
-            writePersistent(ValueIndex.GOAT.IS_SCREAMING, nbt.getBoolean("IsScreamingGoat").orElseThrow());
-    }
-
-    @Override
     public void writeToCompound(CompoundTag nbt)
     {
         super.writeToCompound(nbt);

--- a/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/HappyGhastWatcher.java
+++ b/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/HappyGhastWatcher.java
@@ -35,15 +35,6 @@ public class HappyGhastWatcher extends LivingEntityWatcher
     }
 
     @Override
-    public void mergeFromCompound(CompoundTag nbt)
-    {
-        nbt.getInt("Age")
-                .ifPresent(i -> this.writePersistent(ValueIndex.HAPPY_GHAST.IS_BABY, i < 0));
-
-        super.mergeFromCompound(nbt);
-    }
-
-    @Override
     protected <X> void onPropertyWrite(SingleProperty<X> property, X value)
     {
         if (property.equals(properties.IS_GHASTLING))

--- a/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/HoglinWatcher.java
+++ b/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/HoglinWatcher.java
@@ -1,9 +1,11 @@
 package xyz.nifeather.morph.backends.server.renderer.network.datawatcher.watchers.types;
 
-import net.minecraft.nbt.CompoundTag;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import xyz.nifeather.morph.backends.server.renderer.network.registries.ValueIndex;
+import xyz.nifeather.morph.misc.disguiseProperty.DisguiseProperties;
+import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
+import xyz.nifeather.morph.misc.disguiseProperty.values.HoglinProperties;
 
 public class HoglinWatcher extends EHasAttackAnimationWatcher
 {
@@ -13,19 +15,21 @@ public class HoglinWatcher extends EHasAttackAnimationWatcher
     }
 
     @Override
+    protected <X> void onPropertyWrite(SingleProperty<X> property, X value)
+    {
+        var properties = DisguiseProperties.INSTANCE.getOrThrow(HoglinProperties.class);
+
+        if (property.equals(properties.IS_BABY))
+            this.writePersistent(ValueIndex.AGEABLE_MOB.IS_BABY, (Boolean) value);
+
+        super.onPropertyWrite(property, value);
+    }
+
+    @Override
     protected void initRegistry()
     {
         super.initRegistry();
 
         register(ValueIndex.AGEABLE_MOB);
-    }
-
-    @Override
-    public void mergeFromCompound(CompoundTag nbt)
-    {
-        super.mergeFromCompound(nbt);
-
-        if (nbt.contains("IsBaby"))
-            writePersistent(ValueIndex.AGEABLE_MOB.IS_BABY, nbt.getBoolean("IsBaby").orElseThrow());
     }
 }

--- a/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/LivingEntityWatcher.java
+++ b/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/LivingEntityWatcher.java
@@ -10,6 +10,7 @@ import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerUp
 import it.unimi.dsi.fastutil.Pair;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import it.unimi.dsi.fastutil.objects.ObjectObjectMutablePair;
+import net.kyori.adventure.text.Component;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.ai.attributes.AttributeInstance;
@@ -20,9 +21,13 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.potion.PotionEffect;
+import xyz.nifeather.morph.backends.server.renderer.network.registries.CustomEntries;
 import xyz.nifeather.morph.backends.server.renderer.network.registries.ValueIndex;
 import xyz.nifeather.morph.misc.BuildFailedException;
 import xyz.nifeather.morph.misc.NmsRecord;
+import xyz.nifeather.morph.misc.disguiseProperty.DisguiseProperties;
+import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
+import xyz.nifeather.morph.misc.disguiseProperty.values.BaseLivingEntityProperties;
 import xyz.nifeather.morph.utilities.NmsUtils;
 
 import java.util.List;
@@ -53,6 +58,29 @@ public class LivingEntityWatcher extends EntityWatcher
 
         handPair.left(e.getPlayer());
         handPair.right(e.getHand());
+    }
+
+    @Override
+    protected <X> void onPropertyWrite(SingleProperty<X> property, X value)
+    {
+        var properties = DisguiseProperties.INSTANCE.getOrThrow(BaseLivingEntityProperties.class);
+        if (property.equals(properties.CUSTOM_NAME))
+        {
+            Component component = value instanceof Component component1 ? component1 : Component.empty();
+            this.writePersistent(ValueIndex.BASE_LIVING.CUSTOM_NAME, component.equals(Component.empty()) ? Optional.empty() : Optional.of(component));
+        }
+        else if (property.equals(properties.CUSTOM_NAME_VISIBLE))
+        {
+            Boolean bool = value instanceof Boolean b ? b : Boolean.parseBoolean(value.toString());
+            this.writePersistent(ValueIndex.BASE_LIVING.CUSTOM_NAME_VISIBLE, bool);
+        }
+        else if (property.equals(properties.STUCKED_ARROWS))
+        {
+            int count = (Integer) value;
+            this.writePersistent(ValueIndex.BASE_LIVING.STUCKED_ARROWS, count);
+        }
+
+        super.onPropertyWrite(property, value);
     }
 
     protected WrapperPlayServerUpdateAttributes buildAttributePacket()

--- a/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/MooshroomWatcher.java
+++ b/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/MooshroomWatcher.java
@@ -40,15 +40,6 @@ public class MooshroomWatcher extends LivingEntityWatcher
     }
 
     @Override
-    public void mergeFromCompound(CompoundTag nbt)
-    {
-        super.mergeFromCompound(nbt);
-
-        if (nbt.contains("Type"))
-            writePersistent(ValueIndex.MOOSHROOM.DATA_TYPE, nbt.getString("Type").orElseThrow().equals("red") ? MooshroomValues.RED : MooshroomValues.BROWN);
-    }
-
-    @Override
     public void writeToCompound(CompoundTag nbt)
     {
         super.writeToCompound(nbt);

--- a/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/PandaWatcher.java
+++ b/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/PandaWatcher.java
@@ -78,18 +78,6 @@ public class PandaWatcher extends LivingEntityWatcher
     }
 
     @Override
-    public void mergeFromCompound(CompoundTag nbt)
-    {
-        super.mergeFromCompound(nbt);
-
-        if (nbt.contains("MainGene"))
-            writePersistent(ValueIndex.PANDA.MAIN_GENE, (byte)getGeneFromName(nbt.getString("MainGene").orElseThrow()).ordinal());
-
-        if (nbt.contains("HiddenGene"))
-            writePersistent(ValueIndex.PANDA.HIDDEN_GENE, (byte)getGeneFromName(nbt.getString("HiddenGene").orElseThrow()).ordinal());
-    }
-
-    @Override
     public void writeToCompound(CompoundTag nbt)
     {
         super.writeToCompound(nbt);

--- a/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/ParrotWatcher.java
+++ b/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/ParrotWatcher.java
@@ -39,18 +39,6 @@ public class ParrotWatcher extends TameableAnimalWatcher
     }
 
     @Override
-    public void mergeFromCompound(CompoundTag nbt)
-    {
-        super.mergeFromCompound(nbt);
-
-        if (nbt.contains("Variant"))
-        {
-            var variant = nbt.getInt("Variant").orElseThrow();
-            this.writePersistent(ValueIndex.PARROT.PARROT_VARIANT, variant);
-        }
-    }
-
-    @Override
     public void writeToCompound(CompoundTag nbt)
     {
         super.writeToCompound(nbt);

--- a/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/PhantomWatcher.java
+++ b/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/PhantomWatcher.java
@@ -7,6 +7,9 @@ import org.jetbrains.annotations.Nullable;
 import xyz.nifeather.morph.backends.server.renderer.network.registries.CustomEntries;
 import xyz.nifeather.morph.backends.server.renderer.network.registries.CustomEntry;
 import xyz.nifeather.morph.backends.server.renderer.network.registries.ValueIndex;
+import xyz.nifeather.morph.misc.disguiseProperty.DisguiseProperties;
+import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
+import xyz.nifeather.morph.misc.disguiseProperty.values.PhantomProperties;
 
 import java.util.Objects;
 
@@ -26,21 +29,23 @@ public class PhantomWatcher extends LivingEntityWatcher
     }
 
     @Override
+    protected <X> void onPropertyWrite(SingleProperty<X> property, X value)
+    {
+        var phantomProperties = DisguiseProperties.INSTANCE.getOrThrow(PhantomProperties.class);
+
+        if (property.equals(phantomProperties.SIZE))
+            this.writePersistent(ValueIndex.PHANTOM.SIZE, (Integer) value);
+
+        super.onPropertyWrite(property, value);
+    }
+
+    @Override
     public <X> @Nullable X readEntry(CustomEntry<X> entry)
     {
         if (Objects.equals(entry, CustomEntries.OVERLAYED_PITCH))
             return (X) Float.valueOf(-getBindingPlayer().getPitch());
 
         return super.readEntry(entry);
-    }
-
-    @Override
-    public void mergeFromCompound(CompoundTag nbt)
-    {
-        super.mergeFromCompound(nbt);
-
-        if (nbt.contains("Size"))
-            writePersistent(ValueIndex.PHANTOM.SIZE, nbt.getInt("Size").orElseThrow());
     }
 
     @Override

--- a/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/PigWatcher.java
+++ b/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/PigWatcher.java
@@ -3,7 +3,6 @@ package xyz.nifeather.morph.backends.server.renderer.network.datawatcher.watcher
 import com.github.retrooper.packetevents.protocol.entity.pig.PigVariant;
 import com.github.retrooper.packetevents.protocol.entity.pig.PigVariants;
 import net.minecraft.nbt.CompoundTag;
-import org.bukkit.NamespacedKey;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Pig;
 import org.bukkit.entity.Player;
@@ -50,23 +49,6 @@ public class PigWatcher extends AgeableMobWatcher
         }
 
         super.onPropertyWrite(property, value);
-    }
-
-    @Override
-    public void mergeFromCompound(CompoundTag nbt)
-    {
-        if (nbt.contains("variant"))
-        {
-            var idString = nbt.getString("variant").orElseThrow();
-            var idKey = NamespacedKey.fromString(idString);
-
-            if (idKey == null)
-                return;
-
-            writePersistent(ValueIndex.PIG.PIG_VARIANT, getPigVariant(idString));
-        }
-
-        super.mergeFromCompound(nbt);
     }
 
     @Override

--- a/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/PiglinWatcher.java
+++ b/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/PiglinWatcher.java
@@ -1,6 +1,5 @@
 package xyz.nifeather.morph.backends.server.renderer.network.datawatcher.watchers.types;
 
-import net.minecraft.nbt.CompoundTag;
 import org.bukkit.Sound;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
@@ -47,15 +46,4 @@ public class PiglinWatcher extends LivingEntityWatcher
         }
     }
 
-    @Override
-    public void mergeFromCompound(CompoundTag nbt)
-    {
-        super.mergeFromCompound(nbt);
-
-        if (nbt.contains("IsBaby"))
-            writePersistent(ValueIndex.PIGLIN.IS_BABY, nbt.getBoolean("IsBaby").orElseThrow());
-
-        //if (nbt.contains("IsImmuneToZombification"))
-        //    write(ValueIndex.PIGLIN.IMMUNE_TO_ZOMBIFICATION, nbt.getBoolean("IsImmuneToZombification"));
-    }
 }

--- a/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/PlayerWatcher.java
+++ b/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/PlayerWatcher.java
@@ -10,10 +10,8 @@ import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerPl
 import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerPlayerInfoUpdate;
 import io.github.retrooper.packetevents.util.SpigotConversionUtil;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
-import net.minecraft.nbt.CompoundTag;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
-import org.bukkit.inventory.MainHand;
 import xyz.nifeather.morph.backends.server.renderer.network.registries.CustomEntries;
 import xyz.nifeather.morph.backends.server.renderer.network.registries.CustomEntry;
 import xyz.nifeather.morph.backends.server.renderer.network.registries.ValueIndex;
@@ -64,24 +62,17 @@ public class PlayerWatcher extends InventoryLivingWatcher
     {
         if (property.equals(playerDisguiseProperties.MAIN_HAND))
         {
-            var hand = (MainHand) value;
+            var handStatus = (PlayerProperties.MainHandStatus) value;
+            if (handStatus == PlayerProperties.MainHandStatus.NOTSET)
+                return;
+
+            var hand = handStatus.bindingHand;
+            assert hand != null;
+
             this.writePersistent(ValueIndex.PLAYER.MAINHAND, (byte) hand.ordinal());
         }
 
         super.onPropertyWrite(property, value);
-    }
-
-    @Override
-    public void mergeFromCompound(CompoundTag nbt)
-    {
-        if (nbt.contains("feathermorph:is_left_hand"))
-        {
-            var isLeftHand = nbt.getBoolean("feathermorph:is_left_hand").orElseThrow();
-            int hand = isLeftHand ? MainHand.LEFT.ordinal() : MainHand.RIGHT.ordinal();
-            this.writePersistent(ValueIndex.PLAYER.MAINHAND, (byte)hand);
-        }
-
-        super.mergeFromCompound(nbt);
     }
 
     @Override

--- a/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/RabbitWatcher.java
+++ b/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/RabbitWatcher.java
@@ -47,15 +47,6 @@ public class RabbitWatcher extends LivingEntityWatcher
     }
 
     @Override
-    public void mergeFromCompound(CompoundTag nbt)
-    {
-        super.mergeFromCompound(nbt);
-
-        if (nbt.contains("RabbitType"))
-            writePersistent(ValueIndex.RABBIT.RABBIT_TYPE, nbt.getInt("RabbitType").orElseThrow());
-    }
-
-    @Override
     public void writeToCompound(CompoundTag nbt)
     {
         super.writeToCompound(nbt);

--- a/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/SheepWatcher.java
+++ b/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/SheepWatcher.java
@@ -1,9 +1,13 @@
 package xyz.nifeather.morph.backends.server.renderer.network.datawatcher.watchers.types;
 
 import net.minecraft.nbt.CompoundTag;
+import org.bukkit.DyeColor;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import xyz.nifeather.morph.backends.server.renderer.network.registries.ValueIndex;
+import xyz.nifeather.morph.misc.disguiseProperty.DisguiseProperties;
+import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
+import xyz.nifeather.morph.misc.disguiseProperty.values.SheepProperties;
 
 public class SheepWatcher extends LivingEntityWatcher
 {
@@ -21,12 +25,17 @@ public class SheepWatcher extends LivingEntityWatcher
     }
 
     @Override
-    public void mergeFromCompound(CompoundTag nbt)
+    protected <X> void onPropertyWrite(SingleProperty<X> property, X value)
     {
-        super.mergeFromCompound(nbt);
+        var sheepProperties = DisguiseProperties.INSTANCE.getOrThrow(SheepProperties.class);
 
-        if (nbt.contains("Color"))
-            writePersistent(ValueIndex.SHEEP.WOOL_TYPE, nbt.getByte("Color").orElseThrow());
+        if (property.equals(sheepProperties.DYE_COLOR))
+        {
+            var dyeColor = (DyeColor) value;
+            this.writePersistent(ValueIndex.SHEEP.WOOL_TYPE, dyeColor.getWoolData());
+        }
+
+        super.onPropertyWrite(property, value);
     }
 
     @Override

--- a/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/ShulkerWatcher.java
+++ b/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/ShulkerWatcher.java
@@ -1,5 +1,6 @@
 package xyz.nifeather.morph.backends.server.renderer.network.datawatcher.watchers.types;
 
+import org.bukkit.DyeColor;
 import org.bukkit.Sound;
 import org.bukkit.SoundCategory;
 import org.bukkit.entity.EntityType;
@@ -8,6 +9,9 @@ import xyz.nifeather.morph.backends.server.renderer.network.registries.CustomEnt
 import xyz.nifeather.morph.backends.server.renderer.network.registries.CustomEntry;
 import xyz.nifeather.morph.backends.server.renderer.network.registries.ValueIndex;
 import xyz.nifeather.morph.misc.AnimationNames;
+import xyz.nifeather.morph.misc.disguiseProperty.DisguiseProperties;
+import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
+import xyz.nifeather.morph.misc.disguiseProperty.values.ShulkerProperties;
 
 public class ShulkerWatcher extends LivingEntityWatcher
 {
@@ -22,6 +26,20 @@ public class ShulkerWatcher extends LivingEntityWatcher
         super.initRegistry();
 
         register(ValueIndex.SHULKER);
+    }
+
+    @Override
+    protected <X> void onPropertyWrite(SingleProperty<X> property, X value)
+    {
+        var properties = DisguiseProperties.INSTANCE.getOrThrow(ShulkerProperties.class);
+
+        if (properties.DYE_COLOR.equals(property))
+        {
+            var val = (DyeColor) value;
+            this.writePersistent(ValueIndex.SHULKER.COLOR_ID, val.getWoolData());
+        }
+
+        super.onPropertyWrite(property, value);
     }
 
     @Override

--- a/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/SnowGolemWatcher.java
+++ b/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/SnowGolemWatcher.java
@@ -5,6 +5,9 @@ import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import xyz.nifeather.morph.backends.server.renderer.network.datawatcher.values.SnowGolemValues;
 import xyz.nifeather.morph.backends.server.renderer.network.registries.ValueIndex;
+import xyz.nifeather.morph.misc.disguiseProperty.DisguiseProperties;
+import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
+import xyz.nifeather.morph.misc.disguiseProperty.values.SnowGolemProperties;
 
 public class SnowGolemWatcher extends LivingEntityWatcher
 {
@@ -22,18 +25,17 @@ public class SnowGolemWatcher extends LivingEntityWatcher
     }
 
     @Override
-    public void mergeFromCompound(CompoundTag nbt)
+    protected <X> void onPropertyWrite(SingleProperty<X> property, X value)
     {
-        super.mergeFromCompound(nbt);
+        var snowmanProperties = DisguiseProperties.INSTANCE.getOrThrow(SnowGolemProperties.class);
 
-        if (nbt.contains("Pumpkin"))
+        if (property.equals(snowmanProperties.HAS_PUMPKIN))
         {
-            var value = nbt.getBoolean("Pumpkin").orElseThrow()
-                    ? SnowGolemValues.HAS_PUMPKIN
-                    : SnowGolemValues.NO_PUMPKIN;
-
-            writePersistent(ValueIndex.SNOW_GOLEM.HAT_FLAGS, value);
+            var val = (Boolean) value;
+            this.writePersistent(ValueIndex.SNOW_GOLEM.HAT_FLAGS, val ? SnowGolemValues.HAS_PUMPKIN : SnowGolemValues.NO_PUMPKIN);
         }
+
+        super.onPropertyWrite(property, value);
     }
 
     @Override

--- a/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/TameableAnimalWatcher.java
+++ b/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/TameableAnimalWatcher.java
@@ -7,9 +7,6 @@ import xyz.nifeather.morph.backends.server.renderer.network.registries.ValueInde
 import xyz.nifeather.morph.utilities.NbtUtils;
 import xyz.nifeather.morph.utilities.Uuids;
 
-import java.util.Optional;
-import java.util.UUID;
-
 public class TameableAnimalWatcher extends LivingEntityWatcher
 {
     protected TameableAnimalWatcher(Player bindingPlayer, EntityType entityType)
@@ -23,30 +20,6 @@ public class TameableAnimalWatcher extends LivingEntityWatcher
         super.initRegistry();
 
         register(ValueIndex.TAMEABLE);
-    }
-
-    private final UUID ownerUUID = UUID.randomUUID();
-
-    @Override
-    public void mergeFromCompound(CompoundTag nbt)
-    {
-        super.mergeFromCompound(nbt);
-
-        if (nbt.contains("Owner") && !Uuids.NIL_UUID.equals(NbtUtils.readUUID(nbt.get("Owner"))))
-        {
-            writePersistent(ValueIndex.TAMEABLE.OWNER, Optional.of(ownerUUID));
-
-            byte val = read(ValueIndex.TAMEABLE.TAMEABLE_FLAGS);
-            writePersistent(ValueIndex.TAMEABLE.TAMEABLE_FLAGS, (byte)(val | 0x04));
-        }
-
-        if (nbt.contains("Sitting"))
-        {
-            byte val = read(ValueIndex.TAMEABLE.TAMEABLE_FLAGS);
-
-            if (nbt.getBoolean("Sitting").orElseThrow())
-                writePersistent(ValueIndex.TAMEABLE.TAMEABLE_FLAGS, (byte)(val | 0x01));
-        }
     }
 
     @Override

--- a/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/TropicalFishWatcher.java
+++ b/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/TropicalFishWatcher.java
@@ -4,6 +4,9 @@ import net.minecraft.nbt.CompoundTag;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import xyz.nifeather.morph.backends.server.renderer.network.registries.ValueIndex;
+import xyz.nifeather.morph.misc.disguiseProperty.DisguiseProperties;
+import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
+import xyz.nifeather.morph.misc.disguiseProperty.values.TropicalFishProperties;
 
 public class TropicalFishWatcher extends LivingEntityWatcher
 {
@@ -21,12 +24,17 @@ public class TropicalFishWatcher extends LivingEntityWatcher
     }
 
     @Override
-    public void mergeFromCompound(CompoundTag nbt)
+    protected <X> void onPropertyWrite(SingleProperty<X> property, X value)
     {
-        super.mergeFromCompound(nbt);
+        var tropicalProperties = DisguiseProperties.INSTANCE.getOrThrow(TropicalFishProperties.class);
 
-        if (nbt.contains("Variant"))
-            writePersistent(ValueIndex.TROPICAL.FISH_VARIANT, nbt.getInt("Variant").orElseThrow());
+        if (property.equals(tropicalProperties.VARIANT))
+        {
+            int val = (Integer) value;
+            this.writePersistent(ValueIndex.TROPICAL.FISH_VARIANT, val);
+        }
+
+        super.onPropertyWrite(property, value);
     }
 
     @Override

--- a/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/TropicalFishWatcher.java
+++ b/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/TropicalFishWatcher.java
@@ -1,8 +1,11 @@
 package xyz.nifeather.morph.backends.server.renderer.network.datawatcher.watchers.types;
 
 import net.minecraft.nbt.CompoundTag;
+import org.bukkit.DyeColor;
+import org.bukkit.craftbukkit.entity.CraftTropicalFish;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
+import org.bukkit.entity.TropicalFish;
 import xyz.nifeather.morph.backends.server.renderer.network.registries.ValueIndex;
 import xyz.nifeather.morph.misc.disguiseProperty.DisguiseProperties;
 import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
@@ -23,18 +26,39 @@ public class TropicalFishWatcher extends LivingEntityWatcher
         register(ValueIndex.TROPICAL);
     }
 
+    private volatile DyeColor baseColor = DyeColor.BLACK;
+    private volatile DyeColor patternColor = DyeColor.BLACK;
+    private volatile TropicalFish.Pattern pattern = TropicalFish.Pattern.BLOCKFISH;
+
     @Override
     protected <X> void onPropertyWrite(SingleProperty<X> property, X value)
     {
         var tropicalProperties = DisguiseProperties.INSTANCE.getOrThrow(TropicalFishProperties.class);
 
-        if (property.equals(tropicalProperties.VARIANT))
+        if (property.equals(tropicalProperties.BODY_COLOR))
         {
-            int val = (Integer) value;
-            this.writePersistent(ValueIndex.TROPICAL.FISH_VARIANT, val);
+            logger.info("WRITE BODY COLOR " + value);
+            baseColor = (DyeColor) value;
+            updatePackedData();
+        }
+        else if (property.equals(tropicalProperties.PATTERN_COLOR))
+        {
+            patternColor = (DyeColor) value;
+            updatePackedData();
+        }
+        else if (property.equals(tropicalProperties.PATTERN))
+        {
+            pattern = (TropicalFish.Pattern) value;
+            updatePackedData();
         }
 
         super.onPropertyWrite(property, value);
+    }
+
+    private void updatePackedData()
+    {
+        var data = CraftTropicalFish.getData(patternColor, baseColor, pattern);
+        this.writePersistent(ValueIndex.TROPICAL.FISH_VARIANT, data);
     }
 
     @Override

--- a/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/VillagerWatcher.java
+++ b/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/VillagerWatcher.java
@@ -115,18 +115,6 @@ public class VillagerWatcher extends LivingEntityWatcher
     }
 
     @Override
-    public void mergeFromCompound(CompoundTag nbt)
-    {
-        super.mergeFromCompound(nbt);
-
-        if (nbt.contains("VillagerData"))
-        {
-            var compound = nbt.getCompound("VillagerData").orElseThrow();
-            mergeFromVillagerData(compound);
-        }
-    }
-
-    @Override
     public void writeToCompound(CompoundTag nbt)
     {
         super.writeToCompound(nbt);

--- a/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/WolfWatcher.java
+++ b/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/WolfWatcher.java
@@ -3,11 +3,9 @@ package xyz.nifeather.morph.backends.server.renderer.network.datawatcher.watcher
 import com.github.retrooper.packetevents.protocol.entity.wolfvariant.WolfVariant;
 import com.github.retrooper.packetevents.protocol.entity.wolfvariant.WolfVariants;
 import net.minecraft.nbt.CompoundTag;
-import org.bukkit.NamespacedKey;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Wolf;
-import xyz.nifeather.morph.FeatherMorphMain;
 import xyz.nifeather.morph.backends.server.renderer.network.registries.CustomEntries;
 import xyz.nifeather.morph.backends.server.renderer.network.registries.CustomEntry;
 import xyz.nifeather.morph.backends.server.renderer.network.registries.ValueIndex;
@@ -17,6 +15,8 @@ import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
 import xyz.nifeather.morph.misc.disguiseProperty.values.WolfProperties;
 
 import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
 
 public class WolfWatcher extends TameableAnimalWatcher
 {
@@ -50,6 +50,11 @@ public class WolfWatcher extends TameableAnimalWatcher
 
             this.writePersistent(ValueIndex.WOLF.WOLF_VARIANT, getWolfVariant(val.key().asString()));
         }
+        else if (property.equals(properties.OWNER))
+        {
+            var uuid = (UUID) value;
+            writePersistent(ValueIndex.WOLF.OWNER, Optional.ofNullable(uuid));
+        }
 
         super.onPropertyWrite(property, value);
     }
@@ -68,29 +73,6 @@ public class WolfWatcher extends TameableAnimalWatcher
                 case AnimationNames.SIT -> this.writePersistent(ValueIndex.WOLF.TAMEABLE_FLAGS, (byte)0x01);
                 case AnimationNames.STANDUP -> this.writePersistent(ValueIndex.WOLF.TAMEABLE_FLAGS, (byte)0x00);
             }
-        }
-    }
-
-    @Override
-    public void mergeFromCompound(CompoundTag nbt)
-    {
-        super.mergeFromCompound(nbt);
-
-        if (nbt.contains("CollarColor"))
-            writePersistent(ValueIndex.WOLF.COLLAR_COLOR, (int)nbt.getByte("CollarColor").orElseThrow());
-
-        if (nbt.contains("variant"))
-        {
-            var typeString = nbt.getString("variant").orElseThrow();
-            NamespacedKey key = NamespacedKey.fromString(typeString);;
-
-            if (key == null && FeatherMorphMain.getInstance().doInternalDebugOutput)
-            {
-                logger.warn("[DEBUG] Ignoring unknown variant: " + typeString);
-                return;
-            }
-
-            writePersistent(ValueIndex.WOLF.WOLF_VARIANT, getWolfVariant(typeString));
         }
     }
 

--- a/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/ZoglinWatcher.java
+++ b/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/ZoglinWatcher.java
@@ -1,9 +1,12 @@
 package xyz.nifeather.morph.backends.server.renderer.network.datawatcher.watchers.types;
 
-import net.minecraft.nbt.CompoundTag;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import xyz.nifeather.morph.backends.server.renderer.network.registries.ValueIndex;
+import xyz.nifeather.morph.misc.disguiseProperty.DisguiseProperties;
+import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
+import xyz.nifeather.morph.misc.disguiseProperty.values.HoglinProperties;
+import xyz.nifeather.morph.misc.disguiseProperty.values.ZoglinProperties;
 
 public class ZoglinWatcher extends EHasAttackAnimationWatcher
 {
@@ -13,19 +16,21 @@ public class ZoglinWatcher extends EHasAttackAnimationWatcher
     }
 
     @Override
+    protected <X> void onPropertyWrite(SingleProperty<X> property, X value)
+    {
+        var properties = DisguiseProperties.INSTANCE.getOrThrow(ZoglinProperties.class);
+
+        if (property.equals(properties.IS_BABY))
+            this.writePersistent(ValueIndex.AGEABLE_MOB.IS_BABY, (Boolean) value);
+
+        super.onPropertyWrite(property, value);
+    }
+
+    @Override
     protected void initRegistry()
     {
         super.initRegistry();
 
         register(ValueIndex.ZOGLIN);
-    }
-
-    @Override
-    public void mergeFromCompound(CompoundTag nbt)
-    {
-        super.mergeFromCompound(nbt);
-
-        if (nbt.contains("IsBaby"))
-            writePersistent(ValueIndex.ZOGLIN.IS_BABY, nbt.getBoolean("IsBaby").orElseThrow());
     }
 }

--- a/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/ZombieVillagerWatcher.java
+++ b/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/ZombieVillagerWatcher.java
@@ -13,6 +13,7 @@ import xyz.nifeather.morph.backends.server.renderer.network.registries.ValueInde
 import xyz.nifeather.morph.misc.disguiseProperty.DisguiseProperties;
 import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
 import xyz.nifeather.morph.misc.disguiseProperty.values.VillagerProperties;
+import xyz.nifeather.morph.misc.disguiseProperty.values.ZombieVillagerProperties;
 import xyz.nifeather.morph.utilities.MathUtils;
 
 import java.util.Objects;
@@ -51,7 +52,7 @@ public class ZombieVillagerWatcher extends ZombieWatcher
     @Override
     protected <X> void onPropertyWrite(SingleProperty<X> property, X value)
     {
-        var properties = DisguiseProperties.INSTANCE.getOrThrow(VillagerProperties.class);
+        var properties = DisguiseProperties.INSTANCE.getOrThrow(ZombieVillagerProperties.class);
 
         if (property.equals(properties.LEVEL))
         {
@@ -79,47 +80,12 @@ public class ZombieVillagerWatcher extends ZombieWatcher
         super.onPropertyWrite(property, value);
     }
 
-    private void mergeFromVillagerData(CompoundTag nbt)
-    {
-        int level = 0;
-        VillagerProfession profession = VillagerProfessions.NONE;
-        VillagerType type = VillagerTypes.PLAINS;
-
-        if (nbt.contains("level"))
-            level = MathUtils.clamp(1, 5, nbt.getInt("level").orElseThrow());
-
-        if (nbt.contains("profession"))
-        {
-            var profString = nbt.getString("profession").orElseThrow();
-            var prof = VillagerProfessions.getByName(profString);
-
-            if (prof == null)
-                logger.warn("No such profession '%s', using default".formatted(profString));
-            else
-                profession = prof;
-        }
-
-        if (nbt.contains("type"))
-        {
-            var proftypeString = nbt.getString("type").orElseThrow();
-
-            var typeFromRegistry = VillagerTypes.getByName(proftypeString);
-
-            if (typeFromRegistry == null)
-                logger.warn("No such type '%s', using default".formatted(proftypeString));
-            else
-                type = typeFromRegistry;
-        }
-
-        writePersistent(ValueIndex.VILLAGER.VILLAGER_DATA, new VillagerData(type, profession, level));
-    }
-
     @Override
     public void writeToCompound(CompoundTag nbt)
     {
         super.writeToCompound(nbt);
 
-        var villagerData = read(ValueIndex.VILLAGER.VILLAGER_DATA);
+        var villagerData = read(ValueIndex.ZOMBIE_VILLAGER.VILLAGER_DATA);
         var profession = villagerData.getProfession();
         var type = villagerData.getType();
         var level = villagerData.getLevel();

--- a/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/ZombieVillagerWatcher.java
+++ b/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/ZombieVillagerWatcher.java
@@ -115,15 +115,6 @@ public class ZombieVillagerWatcher extends ZombieWatcher
     }
 
     @Override
-    public void mergeFromCompound(CompoundTag nbt)
-    {
-        super.mergeFromCompound(nbt);
-
-        if (nbt.contains("VillagerData"))
-            mergeFromVillagerData(nbt.getCompound("VillagerData").orElseThrow());
-    }
-
-    @Override
     public void writeToCompound(CompoundTag nbt)
     {
         super.writeToCompound(nbt);

--- a/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/ZombieWatcher.java
+++ b/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/ZombieWatcher.java
@@ -1,9 +1,11 @@
 package xyz.nifeather.morph.backends.server.renderer.network.datawatcher.watchers.types;
 
-import net.minecraft.nbt.CompoundTag;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import xyz.nifeather.morph.backends.server.renderer.network.registries.ValueIndex;
+import xyz.nifeather.morph.misc.disguiseProperty.DisguiseProperties;
+import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
+import xyz.nifeather.morph.misc.disguiseProperty.values.ZombieProperties;
 
 public class ZombieWatcher extends LivingEntityWatcher
 {
@@ -18,19 +20,21 @@ public class ZombieWatcher extends LivingEntityWatcher
     }
 
     @Override
+    protected <X> void onPropertyWrite(SingleProperty<X> property, X value)
+    {
+        var properties = DisguiseProperties.INSTANCE.getOrThrow(ZombieProperties.class);
+
+        if (property.equals(properties.IS_BABY))
+            this.writePersistent(ValueIndex.ZOMBIE.IS_BABY, (Boolean) value);
+
+        super.onPropertyWrite(property, value);
+    }
+
+    @Override
     protected void initRegistry()
     {
         super.initRegistry();
 
         register(ValueIndex.ZOMBIE);
-    }
-
-    @Override
-    public void mergeFromCompound(CompoundTag nbt)
-    {
-        super.mergeFromCompound(nbt);
-
-        if (nbt.contains("IsBaby"))
-            writePersistent(ValueIndex.ZOMBIE.IS_BABY, nbt.getBoolean("IsBaby").orElseThrow());
     }
 }

--- a/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/horses/AbstractHorseWatcher.java
+++ b/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/horses/AbstractHorseWatcher.java
@@ -1,6 +1,5 @@
 package xyz.nifeather.morph.backends.server.renderer.network.datawatcher.watchers.types.horses;
 
-import net.minecraft.nbt.CompoundTag;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import xyz.nifeather.morph.backends.server.renderer.network.datawatcher.watchers.types.AgeableMobWatcher;
@@ -21,12 +20,4 @@ public class AbstractHorseWatcher extends AgeableMobWatcher
         super(bindingPlayer, entityType);
     }
 
-    @Override
-    public void mergeFromCompound(CompoundTag nbt)
-    {
-        super.mergeFromCompound(nbt);
-
-        if (nbt.contains("Age"))
-            writePersistent(ValueIndex.ABSTRACT_HORSE.IS_BABY, nbt.getInt("Age").orElseThrow() < 0);
-    }
 }

--- a/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/horses/ChestedHorseWatcher.java
+++ b/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/horses/ChestedHorseWatcher.java
@@ -1,6 +1,5 @@
 package xyz.nifeather.morph.backends.server.renderer.network.datawatcher.watchers.types.horses;
 
-import net.minecraft.nbt.CompoundTag;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import xyz.nifeather.morph.backends.server.renderer.network.registries.ValueIndex;
@@ -20,12 +19,4 @@ public class ChestedHorseWatcher extends AbstractHorseWatcher
         register(ValueIndex.CHESTED_HORSE);
     }
 
-    @Override
-    public void mergeFromCompound(CompoundTag nbt)
-    {
-        super.mergeFromCompound(nbt);
-
-        if (nbt.contains("ChestedHorse"))
-            writePersistent(ValueIndex.CHESTED_HORSE.HAS_CHEST, nbt.getBoolean("ChestedHorse").orElseThrow());
-    }
 }

--- a/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/horses/HorseWatcher.java
+++ b/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/horses/HorseWatcher.java
@@ -74,15 +74,6 @@ public class HorseWatcher extends AbstractHorseWatcher
     }
 
     @Override
-    public void mergeFromCompound(CompoundTag nbt)
-    {
-        super.mergeFromCompound(nbt);
-
-        if (nbt.contains("Variant"))
-            this.writePersistent(ValueIndex.HORSE.HORSE_VARIANT, nbt.getInt("Variant").orElseThrow());
-    }
-
-    @Override
     public void writeToCompound(CompoundTag nbt)
     {
         super.writeToCompound(nbt);

--- a/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/llama/LlamaWatcher.java
+++ b/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/llama/LlamaWatcher.java
@@ -1,6 +1,5 @@
 package xyz.nifeather.morph.backends.server.renderer.network.datawatcher.watchers.types.llama;
 
-import net.minecraft.nbt.CompoundTag;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Llama;
 import org.bukkit.entity.Player;
@@ -43,20 +42,5 @@ public class LlamaWatcher extends ChestedHorseWatcher
         }
 
         super.onPropertyWrite(property, value);
-    }
-
-    @Override
-    public void mergeFromCompound(CompoundTag nbt)
-    {
-        super.mergeFromCompound(nbt);
-
-        if (nbt.contains("Strength"))
-            writePersistent(ValueIndex.LLAMA.SLOTS, nbt.getInt("Strength").orElseThrow());
-
-        if (nbt.contains("DecorItem"))
-            logger.warn("todo: Llama DecorItem is not implemented.");
-
-        if (nbt.contains("Variant"))
-            writePersistent(ValueIndex.LLAMA.VARIANT, nbt.getInt("Variant").orElseThrow());
     }
 }

--- a/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/llama/TraderLlamaWatcher.java
+++ b/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/llama/TraderLlamaWatcher.java
@@ -1,8 +1,13 @@
 package xyz.nifeather.morph.backends.server.renderer.network.datawatcher.watchers.types.llama;
 
 import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Llama;
 import org.bukkit.entity.Player;
 import xyz.nifeather.morph.backends.server.renderer.network.registries.ValueIndex;
+import xyz.nifeather.morph.misc.disguiseProperty.DisguiseProperties;
+import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
+import xyz.nifeather.morph.misc.disguiseProperty.values.LlamaProperties;
+import xyz.nifeather.morph.misc.disguiseProperty.values.TraderLlamaProperties;
 
 public class TraderLlamaWatcher extends LlamaWatcher
 {

--- a/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/slimemagma/AbstractSlimeWatcher.java
+++ b/src/main/java/xyz/nifeather/morph/backends/server/renderer/network/datawatcher/watchers/types/slimemagma/AbstractSlimeWatcher.java
@@ -6,6 +6,9 @@ import org.bukkit.entity.Player;
 import xyz.nifeather.morph.backends.server.renderer.network.datawatcher.watchers.types.LivingEntityWatcher;
 import xyz.nifeather.morph.backends.server.renderer.network.registries.CustomEntries;
 import xyz.nifeather.morph.backends.server.renderer.network.registries.ValueIndex;
+import xyz.nifeather.morph.misc.disguiseProperty.DisguiseProperties;
+import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
+import xyz.nifeather.morph.misc.disguiseProperty.values.SlimeMagmaProperties;
 
 public class AbstractSlimeWatcher extends LivingEntityWatcher
 {
@@ -23,18 +26,18 @@ public class AbstractSlimeWatcher extends LivingEntityWatcher
     }
 
     @Override
-    public void mergeFromCompound(CompoundTag nbt)
+    protected <X> void onPropertyWrite(SingleProperty<X> property, X value)
     {
-        super.mergeFromCompound(nbt);
+        var properties = DisguiseProperties.INSTANCE.getOrThrow(SlimeMagmaProperties.class);
 
-        if (nbt.contains("Size"))
+        if (property.equals(properties.SIZE))
         {
-            // 史莱姆在通信时的大小比NBT中的大 1
-            // 即：最小的史莱姆在NBT中的大小为0，在通信时传输的大小是1
-            var size = Math.max(0, nbt.getInt("Size").orElseThrow());
-            writePersistent(ValueIndex.SLIME_MAGMA.SIZE, size + 1);
-            writeEntry(CustomEntries.SLIME_SIZE_REAL, size);
+            var size = (int) value;
+            this.writeEntry(CustomEntries.SLIME_SIZE_REAL, size);
+            this.writePersistent(ValueIndex.SLIME_MAGMA.SIZE, size);
         }
+
+        super.onPropertyWrite(property, value);
     }
 
     @Override

--- a/src/main/java/xyz/nifeather/morph/misc/DisguiseState.java
+++ b/src/main/java/xyz/nifeather/morph/misc/DisguiseState.java
@@ -698,19 +698,11 @@ public class DisguiseState extends MorphPluginObject
 
     //endregion abilityFlag
 
-    //region NBT
-
-    public String getFullNbtString()
+    @Deprecated
+    public String getCulledNbtString()
     {
         return NbtUtils.getCompoundString(disguiseWrapper.getCompound());
     }
-
-    public String getCulledNbtString()
-    {
-        return NbtUtils.getCompoundString(DisguiseProvider.cullNBT(disguiseWrapper.getCompound()));
-    }
-
-    //endregion
 
     //region ProfileNBT
 
@@ -719,8 +711,7 @@ public class DisguiseState extends MorphPluginObject
         if (!haveProfile())
              return "{}";
 
-        var s = NbtUtils.getCompoundString(NbtUtils.toCompoundTag(disguiseWrapper.getSkin()));
-        return s;
+        return NbtUtils.getCompoundString(NbtUtils.toCompoundTag(disguiseWrapper.getSkin()));
     }
 
     public boolean haveProfile()

--- a/src/main/java/xyz/nifeather/morph/misc/DisguiseState.java
+++ b/src/main/java/xyz/nifeather/morph/misc/DisguiseState.java
@@ -882,7 +882,6 @@ public class DisguiseState extends MorphPluginObject
         this.disguiseWrapper.dispose();
         this.abilityUpdater.dispose();
 
-        this.provider.resetDisguise(this);
         this.provider.unMorph(getPlayer(), this);
         this.abilityUpdater.setAbilities(List.of());
         this.setSkill(null, null);

--- a/src/main/java/xyz/nifeather/morph/misc/DisguiseStateGenerator.java
+++ b/src/main/java/xyz/nifeather/morph/misc/DisguiseStateGenerator.java
@@ -29,7 +29,6 @@ public class DisguiseStateGenerator
 
         offlineState.disguiseData = "%s|%s".formatted(backend.getIdentifier(), backend.toOfflineSave(newDisguise));
         offlineState.displayingDisguisedItems = state.showingDisguisedItems();
-        offlineState.snbt = state.getFullNbtString();
         offlineState.profileString = state.getProfileNbtString();
 
         if (state.entityCustomName != null)
@@ -95,10 +94,6 @@ public class DisguiseStateGenerator
             var logger = FeatherMorphMain.getInstance().getSLF4JLogger();
             logger.error("Unable to parse profile data: " + t.getMessage());
         }
-
-        var compound = NbtUtils.toCompoundTag(offlineState.snbt);
-        if (compound != null)
-            state.getDisguiseWrapper().mergeCompound(compound);
 
         //设置显示名称
         if (offlineState.customName != null)

--- a/src/main/java/xyz/nifeather/morph/misc/ModNetworkingHelper.java
+++ b/src/main/java/xyz/nifeather/morph/misc/ModNetworkingHelper.java
@@ -121,7 +121,7 @@ public class ModNetworkingHelper extends MorphPluginObject
             var profileStr = NbtUtils.getCompoundString(NbtUtils.toCompoundTag(profile));
 
             this.setProfileCompound(profileStr)
-                    .setSNbt(NbtUtils.getCompoundString(wrapper.getCompound()))
+                    //.setSNbt(NbtUtils.getCompoundString(wrapper.getCompound()))
                     .setDisguiseEquipmentShown(wrapper.readProperty(OffTreeProperties.DISPLAY_FAKE_EQUIPMENT))
                     .setOverridedEquip(wrapper.getFakeEquipments());
 

--- a/src/main/java/xyz/nifeather/morph/misc/MorphParameters.java
+++ b/src/main/java/xyz/nifeather/morph/misc/MorphParameters.java
@@ -37,7 +37,7 @@ public class MorphParameters
     @Nullable
     public Entity targetedEntity;
 
-    public final Map<String, String> properties = new ConcurrentHashMap<>();
+    public final Map<String, String> propertiesInput = new ConcurrentHashMap<>();
 
     public MorphParameters setSource(CommandSender sender)
     {
@@ -76,14 +76,14 @@ public class MorphParameters
 
     public MorphParameters withProperties(Map<String, String> map)
     {
-        this.properties.putAll(map);
+        this.propertiesInput.putAll(map);
 
         return this;
     }
 
     public MorphParameters withProperties(@NotNull String key, @NotNull String value)
     {
-        this.properties.put(key, value);
+        this.propertiesInput.put(key, value);
 
         return this;
     }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/DisguiseProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/DisguiseProperties.java
@@ -6,6 +6,7 @@ import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import xiamomc.pluginbase.Exceptions.NullDependencyException;
+import xyz.nifeather.morph.misc.DisguiseState;
 import xyz.nifeather.morph.misc.disguiseProperty.values.*;
 
 import java.util.Map;
@@ -16,7 +17,7 @@ public class DisguiseProperties
     public static final DisguiseProperties INSTANCE = new DisguiseProperties();
     private static final Logger log = LoggerFactory.getLogger(DisguiseProperties.class);
 
-    private final Map<EntityType, AbstractProperties> handlerMap = new ConcurrentHashMap<>();
+    private final Map<EntityType, AbstractProperties<?>> handlerMap = new ConcurrentHashMap<>();
 
     private DisguiseProperties()
     {
@@ -33,7 +34,7 @@ public class DisguiseProperties
         register(EntityType.HORSE, new HorseProperties());
         register(EntityType.PANDA, new PandaProperties());
         register(EntityType.VILLAGER, new VillagerProperties());
-        register(EntityType.ZOMBIE_VILLAGER, new VillagerProperties());
+        register(EntityType.ZOMBIE_VILLAGER, new ZombieVillagerProperties());
         register(EntityType.ARMOR_STAND, new ArmorStandProperties());
         register(EntityType.CREEPER, new CreeperProperties());
 
@@ -45,14 +46,30 @@ public class DisguiseProperties
         register(EntityType.HAPPY_GHAST, new HappyGhastProperties());
 
         register(EntityType.PLAYER, new PlayerProperties());
+
+        var slimeMagmaProperties = new SlimeMagmaProperties();
+        register(EntityType.SLIME, slimeMagmaProperties);
+        register(EntityType.MAGMA_CUBE, slimeMagmaProperties);
+
+        register(EntityType.SHULKER, new ShulkerProperties());
+        register(EntityType.TRADER_LLAMA, new TraderLlamaProperties());
+        register(EntityType.PHANTOM, new PhantomProperties());
+        register(EntityType.SHEEP, new SheepProperties());
+        register(EntityType.SNOW_GOLEM, new SnowGolemProperties());
+        register(EntityType.TROPICAL_FISH, new TropicalFishProperties());
+
+        register(EntityType.HOGLIN, new HoglinProperties());
+        register(EntityType.ZOGLIN, new ZoglinProperties());
+
+        register(EntityType.ZOMBIE, new ZombieProperties());
     }
 
-    public Map<EntityType, AbstractProperties> getAll()
+    public Map<EntityType, AbstractProperties<?>> getAll()
     {
         return new Object2ObjectOpenHashMap<>(handlerMap);
     }
 
-    public void register(EntityType type, AbstractProperties properties)
+    public void register(EntityType type, AbstractProperties<?> properties)
     {
         if (handlerMap.containsKey(type))
             throw new IllegalArgumentException("Already contains properties setup for type " + type);
@@ -60,7 +77,7 @@ public class DisguiseProperties
         handlerMap.put(type, properties);
     }
 
-    private static final AbstractProperties defaultProperties = new DefaultProperties();
+    private static final AbstractProperties<?> defaultProperties = new DefaultProperties();
 
     public <X> X getOrThrow(Class<X> expectedClass)
     {
@@ -86,7 +103,7 @@ public class DisguiseProperties
     }
 
     @NotNull
-    public AbstractProperties get(EntityType type)
+    public AbstractProperties<?> get(EntityType type)
     {
         return handlerMap.getOrDefault(type, defaultProperties);
     }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/DisguiseProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/DisguiseProperties.java
@@ -6,7 +6,6 @@ import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import xiamomc.pluginbase.Exceptions.NullDependencyException;
-import xyz.nifeather.morph.misc.DisguiseState;
 import xyz.nifeather.morph.misc.disguiseProperty.values.*;
 
 import java.util.Map;
@@ -77,7 +76,7 @@ public class DisguiseProperties
         handlerMap.put(type, properties);
     }
 
-    private static final AbstractProperties<?> defaultProperties = new DefaultProperties();
+    private static final AbstractProperties<?> defaultProperties = new FallbackProperties();
 
     public <X> X getOrThrow(Class<X> expectedClass)
     {

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/PropertyHandler.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/PropertyHandler.java
@@ -7,13 +7,9 @@ import org.jetbrains.annotations.Nullable;
 import xyz.nifeather.morph.FeatherMorphMain;
 import xyz.nifeather.morph.misc.disguiseProperty.values.AbstractProperties;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Random;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.ThreadLocalRandom;
 
 public class PropertyHandler
 {
@@ -92,8 +88,13 @@ public class PropertyHandler
         return this.getOr(property, property.defaultVal());
     }
 
+    public <X> Optional<X> getOptional(SingleProperty<X> property)
+    {
+        return Optional.ofNullable(getOr(property, null));
+    }
+
     @Nullable
-    @Contract("_, null -> null; _, !null -> !null")
+    @Contract("_, null -> _; _, !null -> !null")
     public <X> X getOr(SingleProperty<X> property, X defaultVal)
     {
         return (X) propertyMap.getOrDefault(property, defaultVal);

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/PropertyHandler.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/PropertyHandler.java
@@ -7,6 +7,7 @@ import org.jetbrains.annotations.Nullable;
 import xyz.nifeather.morph.FeatherMorphMain;
 import xyz.nifeather.morph.misc.disguiseProperty.values.AbstractProperties;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -19,46 +20,45 @@ public class PropertyHandler
     private final Map<SingleProperty<?>, Object> propertyMap = new ConcurrentHashMap<>();
     private final List<SingleProperty<?>> validProperties = new CopyOnWriteArrayList<>();
 
-    private final Random random = ThreadLocalRandom.current();
+    public Map<String, String> toNetworkProperties()
+    {
+        if (bindingProperties == null)
+        {
+            FeatherMorphMain.getInstance().getSLF4JLogger().warn("Trying to map network properties while a PropertyHandler has not been initialized?!");
+
+            return new HashMap<>();
+        }
+
+        return bindingProperties.mapToNetworkProperties(this);
+    }
 
     @Nullable
-    private AbstractProperties properties;
+    private AbstractProperties<?> bindingProperties;
 
-    public void initProperties(AbstractProperties properties)
+    public void initProperties(AbstractProperties<?> properties)
     {
         reset();
 
-        this.properties = properties;
+        this.bindingProperties = properties;
         validProperties.addAll(properties.getValues());
-        properties.getValues().forEach(this::initProperty);
     }
 
     public void updateFromPropertiesInput(Map<String, String> input)
     {
-        if (this.properties == null)
+        if (this.bindingProperties == null)
         {
-            FeatherMorphMain.getInstance().getSLF4JLogger().warn("Trying to update property input while the PropertyHandler has not been initialized?!");
+            FeatherMorphMain.getInstance().getSLF4JLogger().warn("Trying to update property input while a PropertyHandler has not been initialized?!");
             return;
         }
 
-        var results = this.properties.readFromPropertiesInput(input);
+        var results = this.bindingProperties.readFromPropertiesInput(input);
         results.forEach(this::writeGeneric);
-    }
-
-    private void initProperty(SingleProperty<?> property)
-    {
-        var random = property.getRandomValues();
-        if (!random.isEmpty())
-        {
-            var index = this.random.nextInt(random.size());
-            this.writeGeneric(property, random.get(index));
-        }
     }
 
     public void reset()
     {
         this.validProperties.clear();
-        this.properties = null;
+        this.bindingProperties = null;
         propertyMap.clear();
     }
 
@@ -74,7 +74,7 @@ public class PropertyHandler
     {
         if (!validProperties.contains(property))
         {
-            FeatherMorphMain.getInstance().getSLF4JLogger().warn("The given property '%s' doesn't exist in '%s'".formatted(property.id(), this.properties));
+            FeatherMorphMain.getInstance().getSLF4JLogger().warn("The given property '%s' doesn't exist in '%s'".formatted(property.id(), this.bindingProperties));
             return;
         }
 

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/PropertyHandler.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/PropertyHandler.java
@@ -104,4 +104,31 @@ public class PropertyHandler
     {
         return new Object2ObjectArrayMap<>(propertyMap);
     }
+
+    /**
+     * Execute a simple copy which copies our value to the given PropertyHandler
+     */
+    public void copyTo(PropertyHandler other)
+    {
+        this.propertyMap.forEach((k, v) ->
+        {
+            other.set((SingleProperty<Object>) k, v);
+        });
+    }
+
+    /**
+     * Check if the given PropertyHandler has been set up with the same properties of this handler
+     */
+    public boolean bindingPropertiesEquals(PropertyHandler other)
+    {
+        return other.bindingProperties != null && this.bindingPropertiesEquals(other.bindingProperties);
+    }
+
+    /**
+     * Check if the given Properties is same properties of this handler
+     */
+    public boolean bindingPropertiesEquals(AbstractProperties<?> other)
+    {
+        return this.bindingProperties != null && this.bindingProperties.equals(other);
+    }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/PropertyNames.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/PropertyNames.java
@@ -1,0 +1,89 @@
+package xyz.nifeather.morph.misc.disguiseProperty;
+
+public class PropertyNames
+{
+    public static final String PLAYER_MAIN_HAND = "player/main_hand";
+
+    public static final String ENTITY_ARROW_COUNT = "entity/stucked_arrows";
+    public static final String ENTITY_CUSTOM_NAME = "entity/custom_name";
+    public static final String ENTITY_CUSTOM_NAME_VISIBLE = "entity/custom_name_visible";
+
+    public static final String AXOLOTL_VARIANT = "axolotl/variant";
+
+    public static final String ARMOR_STAND_SHOW_ARMS = "armor_stand/show_arms";
+    public static final String ARMOR_STAND_HAS_BASE_PLATE = "armor_stand/has_base_plate";
+    public static final String ARMOR_STAND_SMALL = "armor_stand/small";
+    public static final String ARMOR_STAND_HEAD_ROTATION = "armor_stand/head_rotation";
+    public static final String ARMOR_STAND_BODY_ROTATION = "armor_stand/body_rotation";
+    public static final String ARMOR_STAND_LEFT_ARM_ROTATION = "armor_stand/left_arm_rotation";
+    public static final String ARMOR_STAND_RIGHT_ARM_ROTATION = "armor_stand/right_arm_rotation";
+    public static final String ARMOR_STAND_LEFT_LEG_ROTATION = "armor_stand/left_leg_rotation";
+    public static final String ARMOR_STAND_RIGHT_LEG_ROTATION = "armor_stand/right_leg_rotation";
+
+    public static final String CAT_VARIANT = "cat/variant";
+    public static final String CAT_OWNER = "cat/owner";
+
+    public static final String CHICKEN_VARIANT = "chicken/variant";
+
+    public static final String COW_VARIANT = "cow/variant";
+
+    public static final String CREEPER_CHARGED = "creeper/charged";
+
+    public static final String ENDER_DRAGON_DRAGON_PHASE = "ender_dragon/dragon_phase";
+
+    public static final String FOX_VARIANT = "fox/variant";
+
+    public static final String FROG_VARIANT = "frog/variant";
+
+    public static final String GOAT_HAS_LEFT_HORN = "goat/has_left_horn";
+    public static final String GOAT_HAS_RIGHT_HORN = "goat/has_right_horn";
+
+    public static final String HAPPY_GHAST_IS_GHASTLING = "happy_ghast/ghastling";
+
+    public static final String HOGLIN_IS_BABY = "hoglin/is_baby";
+    public static final String ZOGLIN_IS_BABY = "zoglin/is_baby";
+
+    public static final String HORSE_COLOR = "horse/color";
+    public static final String HORSE_STYLE = "horse/style";
+
+    public static final String LLAMA_COLOR = "llama/color";
+
+    public static final String MOOSHROOM_VARIANT = "mooshroom/variant";
+
+    public static final String PANDA_MAIN_GENE = "panda/main_gene";
+    public static final String PANDA_HIDDEN_GENE = "panda/hidden_gene";
+
+    public static final String PARROT_VARIANT = "parrot/variant";
+
+    public static final String PHANTOM_SIZE = "phantom/size";
+
+    public static final String PIG_VARIANT = "pig/variant";
+
+    public static final String RABBIT_VARIANT = "rabbit/variant";
+
+    public static final String SHEEP_COLOR = "sheep/color";
+
+    public static final String SHULKER_COLOR = "shulker/color";
+
+    public static final String SLIME_MAGMA_SIZE = "slime_magma/size";
+
+    public static final String SNOW_GOLEM_HAS_PUMPKIN = "snow_golem/pumpkin";
+
+    public static final String TROPICAL_FISH_BODY_COLOR = "tropical_fish/body_color";
+    public static final String TROPICAL_FISH_PATTERN_COLOR = "tropical_fish/pattern_color";
+    public static final String TROPICAL_FISH_PATTERN = "tropical_fish/pattern";
+
+    public static final String VILLAGER_TYPE = "villager/type";
+    public static final String VILLAGER_PROFESSION = "villager/profession";
+    public static final String VILLAGER_LEVEL = "villager/level";
+
+    public static final String WOLF_OWNER = "wolf/owner";
+    public static final String WOLF_VARIANT = "wolf/variant";
+
+    public static final String ZOMBIE_IS_BABY = "zombie/is_baby";
+
+    public static final String ZOMBIE_VILLAGER_IS_BABY = "zombie_villager/is_baby";
+    public static final String ZOMBIE_VILLAGER_TYPE = "zombie_villager/type";
+    public static final String ZOMBIE_VILLAGER_PROFESSION = "zombie_villager/profession";
+    public static final String ZOMBIE_VILLAGER_LEVEL = "zombie_villager/level";
+}

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/SingleProperty.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/SingleProperty.java
@@ -1,18 +1,22 @@
 package xyz.nifeather.morph.misc.disguiseProperty;
 
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.Unmodifiable;
 
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Function;
 
 public class SingleProperty<T>
 {
     private final String identifier;
     private final T defaultVal;
     private final Class<T> type;
+    private final Function<String, Optional<T>> inputHandle;
 
     public String id()
     {
@@ -29,11 +33,26 @@ public class SingleProperty<T>
         return type;
     }
 
+    public Optional<T> forInput(String input)
+    {
+        return inputHandle.apply(input);
+    }
+
+    @Deprecated
     public SingleProperty(String identifier, T defaultValue, Class<T> type)
     {
+        this(identifier, defaultValue, type, null);
+    }
+
+    public SingleProperty(String identifier, T defaultValue, Class<T> type, @Nullable Function<String, Optional<T>> inputHandle)
+    {
+        if (inputHandle == null)
+            inputHandle = str -> Optional.empty();
+
         this.identifier = identifier;
         this.defaultVal = defaultValue;
         this.type = type;
+        this.inputHandle = inputHandle;
     }
 
     private final List<String> validValues = new CopyOnWriteArrayList<>();
@@ -90,5 +109,10 @@ public class SingleProperty<T>
     public static <T> SingleProperty<T> of(String id, T val)
     {
         return new SingleProperty<>(id, val, (Class<T>) val.getClass());
+    }
+
+    public static <T> SingleProperty<T> of(String id, T val, Function<String, Optional<T>> inputHandle)
+    {
+        return new SingleProperty<>(id, val, (Class<T>) val.getClass(), inputHandle);
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/AbstractProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/AbstractProperties.java
@@ -84,5 +84,13 @@ public abstract class AbstractProperties<E extends Entity>
     protected abstract void setupPropertiesFromEntity(PropertyHandler propertyHandler, @NotNull E targetEntity);
     protected abstract void setupDefaultProperties(PropertyHandler propertyHandler);
 
-    public abstract Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler);
+    public final Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
+    {
+        var map = new ConcurrentHashMap<String, String>();
+        this.appendNetworkMap(propertyHandler, map);
+
+        return map;
+    }
+
+    protected abstract void appendNetworkMap(PropertyHandler propertyHandler, Map<String, String> map);
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/AbstractProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/AbstractProperties.java
@@ -2,9 +2,13 @@ package xyz.nifeather.morph.misc.disguiseProperty.values;
 
 import it.unimi.dsi.fastutil.Pair;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+import org.bukkit.entity.Entity;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import xyz.nifeather.morph.FeatherMorphMain;
+import xyz.nifeather.morph.misc.DisguiseState;
+import xyz.nifeather.morph.misc.disguiseProperty.PropertyHandler;
 import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
 
 import java.util.List;
@@ -12,7 +16,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 
-public abstract class AbstractProperties
+public abstract class AbstractProperties<E extends Entity>
 {
     protected <X> SingleProperty<X> getSingle(String name, X val)
     {
@@ -63,4 +67,22 @@ public abstract class AbstractProperties
 
         return map;
     }
+
+    @Nullable
+    protected abstract E tryCastEntity(@Nullable Entity targetEntity);
+
+    public final void setupProperties(DisguiseState state, @Nullable Entity targetEntity)
+    {
+        var cast = tryCastEntity(targetEntity);
+
+        if (cast != null)
+            setupPropertiesFromEntity(state.disguisePropertyHandler(), cast);
+        else
+            setupDefaultProperties(state.disguisePropertyHandler());
+    }
+
+    protected abstract void setupPropertiesFromEntity(PropertyHandler propertyHandler, @NotNull E targetEntity);
+    protected abstract void setupDefaultProperties(PropertyHandler propertyHandler);
+
+    public abstract Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler);
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/AbstractProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/AbstractProperties.java
@@ -7,12 +7,14 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import xyz.nifeather.morph.FeatherMorphMain;
+import xyz.nifeather.morph.api.FeatherMorphAPI;
 import xyz.nifeather.morph.misc.DisguiseState;
 import xyz.nifeather.morph.misc.disguiseProperty.PropertyHandler;
 import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 
@@ -71,8 +73,28 @@ public abstract class AbstractProperties<E extends Entity>
     @Nullable
     protected abstract E tryCastEntity(@Nullable Entity targetEntity);
 
+    protected boolean validateOtherDisguise(DisguiseState our, DisguiseState other)
+    {
+        return our.disguisePropertyHandler().bindingPropertiesEquals(other.disguisePropertyHandler());
+    }
+
     public final void setupProperties(DisguiseState state, @Nullable Entity targetEntity)
     {
+        var theirDisguise = Objects.requireNonNull(FeatherMorphAPI.instance())
+                .directAccess()
+                .morphManager()
+                .getDisguiseStateFor(targetEntity);
+
+        // Clone if the target entity is disguised.
+        // If their disguise is not compatible with ours, we don't want to continue cloning from them anyway
+        if (theirDisguise != null)
+        {
+            if (validateOtherDisguise(state, theirDisguise))
+                this.setupFromOtherDisguise(state, theirDisguise);
+
+            return;
+        }
+
         var cast = tryCastEntity(targetEntity);
 
         if (cast != null)
@@ -83,6 +105,14 @@ public abstract class AbstractProperties<E extends Entity>
 
     protected abstract void setupPropertiesFromEntity(PropertyHandler propertyHandler, @NotNull E targetEntity);
     protected abstract void setupDefaultProperties(PropertyHandler propertyHandler);
+
+    protected void setupFromOtherDisguise(DisguiseState ourState, DisguiseState theirState)
+    {
+        var ourHandler = ourState.disguisePropertyHandler();
+        var theirHandler = theirState.disguisePropertyHandler();
+
+        theirHandler.copyTo(ourHandler);
+    }
 
     public final Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
     {

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/ArmorStandProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/ArmorStandProperties.java
@@ -1,34 +1,36 @@
 package xyz.nifeather.morph.misc.disguiseProperty.values;
 
-import com.github.retrooper.packetevents.util.Vector3f;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import io.papermc.paper.math.Rotations;
+import it.unimi.dsi.fastutil.Function;
 import it.unimi.dsi.fastutil.Pair;
 import org.bukkit.entity.ArmorStand;
 import org.bukkit.entity.Entity;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import xyz.nifeather.morph.misc.disguiseProperty.PropertyHandler;
+import xyz.nifeather.morph.misc.disguiseProperty.PropertyNames;
 import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
 
+import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.Optional;
 
 public class ArmorStandProperties extends BaseLivingEntityProperties<ArmorStand>
 {
-    public final SingleProperty<Boolean> SHOW_ARMS = getSingle("armor_stand/show_arms", false).withValidInput("true", "false");
-    public final SingleProperty<Boolean> HAS_BASE_PLATE = getSingle("armor_stand/has_base_plate", true)
+    public final SingleProperty<Boolean> SHOW_ARMS = getSingle(PropertyNames.ARMOR_STAND_SHOW_ARMS, false).withValidInput("true", "false");
+    public final SingleProperty<Boolean> HAS_BASE_PLATE = getSingle(PropertyNames.ARMOR_STAND_HAS_BASE_PLATE, true)
             .withValidInput("true", "false");
-    public final SingleProperty<Boolean> SMALL = getSingle("armor_stand/small", false)
+    public final SingleProperty<Boolean> SMALL = getSingle(PropertyNames.ARMOR_STAND_SMALL, false)
             .withValidInput("true", "false");
 
-    public final SingleProperty<Vector3f> HEAD_ROTATION = getSingle("armor_stand/head_rotation", Vector3f.zero());
-    public final SingleProperty<Vector3f> BODY_ROTATION = getSingle("armor_stand/body_rotation", Vector3f.zero());
-    public final SingleProperty<Vector3f> RIGHT_ARM_ROTATION = getSingle("armor_stand/right_arm_rotation", Vector3f.zero());
-    public final SingleProperty<Vector3f> LEFT_ARM_ROTATION = getSingle("armor_stand/left_arm_rotation", Vector3f.zero());
-    public final SingleProperty<Vector3f> RIGHT_LEG_ROTATION = getSingle("armor_stand/right_leg_rotation", Vector3f.zero());
-    public final SingleProperty<Vector3f> LEFT_LEG_ROTATION = getSingle("armor_stand/left_leg_rotation", Vector3f.zero());
+    public final SingleProperty<Rotations> HEAD_ROTATION = getSingle(PropertyNames.ARMOR_STAND_HEAD_ROTATION, Rotations.ZERO);
+    public final SingleProperty<Rotations> BODY_ROTATION = getSingle(PropertyNames.ARMOR_STAND_BODY_ROTATION, Rotations.ZERO);
+    public final SingleProperty<Rotations> RIGHT_ARM_ROTATION = getSingle(PropertyNames.ARMOR_STAND_RIGHT_ARM_ROTATION, Rotations.ZERO);
+    public final SingleProperty<Rotations> LEFT_ARM_ROTATION = getSingle(PropertyNames.ARMOR_STAND_LEFT_ARM_ROTATION, Rotations.ZERO);
+    public final SingleProperty<Rotations> RIGHT_LEG_ROTATION = getSingle(PropertyNames.ARMOR_STAND_RIGHT_LEG_ROTATION, Rotations.ZERO);
+    public final SingleProperty<Rotations> LEFT_LEG_ROTATION = getSingle(PropertyNames.ARMOR_STAND_LEFT_LEG_ROTATION, Rotations.ZERO);
 
     public ArmorStandProperties()
     {
@@ -40,14 +42,77 @@ public class ArmorStandProperties extends BaseLivingEntityProperties<ArmorStand>
     @Override
     protected @Nullable Pair<SingleProperty<?>, Object> parseSingleInput(String key, String value)
     {
-        if (key.equals(SHOW_ARMS.id()))
-            return Pair.of(SHOW_ARMS, Boolean.valueOf(value));
-        else if (key.equals(HAS_BASE_PLATE.id()))
-            return Pair.of(HAS_BASE_PLATE, Boolean.valueOf(value));
-        else if (key.equals(SMALL.id()))
-            return Pair.of(SMALL, Boolean.valueOf(value));
+        return switch (key)
+        {
+            case PropertyNames.ARMOR_STAND_SHOW_ARMS -> Pair.of(SHOW_ARMS, Boolean.valueOf(value));
+            case PropertyNames.ARMOR_STAND_HAS_BASE_PLATE -> Pair.of(HAS_BASE_PLATE, Boolean.valueOf(value));
+            case PropertyNames.ARMOR_STAND_SMALL -> Pair.of(SMALL, Boolean.valueOf(value));
 
-        return super.parseSingleInput(key, value);
+            case PropertyNames.ARMOR_STAND_HEAD_ROTATION -> parseRotatins(HEAD_ROTATION, value);
+            case PropertyNames.ARMOR_STAND_BODY_ROTATION -> parseRotatins(BODY_ROTATION, value);
+            case PropertyNames.ARMOR_STAND_RIGHT_ARM_ROTATION -> parseRotatins(RIGHT_ARM_ROTATION, value);
+            case PropertyNames.ARMOR_STAND_LEFT_ARM_ROTATION -> parseRotatins(LEFT_ARM_ROTATION, value);
+            case PropertyNames.ARMOR_STAND_RIGHT_LEG_ROTATION -> parseRotatins(RIGHT_LEG_ROTATION, value);
+            case PropertyNames.ARMOR_STAND_LEFT_LEG_ROTATION -> parseRotatins(LEFT_LEG_ROTATION, value);
+
+            default -> super.parseSingleInput(key, value);
+        };
+    }
+
+    @Nullable
+    private Pair<SingleProperty<?>, Object> parseRotatins(SingleProperty<Rotations> property, String input)
+    {
+        var rot = this.readRotations(input);
+
+        return rot.<Pair<SingleProperty<?>, Object>>map(rotations -> Pair.of(property, rotations))
+                .orElse(null);
+    }
+
+    public static class RotationStore
+    {
+        private float x, y, z;
+
+        public void x(float v) { x = v; }
+        public void y(float v) { y = v; }
+        public void z(float v) { z = v; }
+
+        public Rotations toRotations()
+        {
+            return Rotations.ofDegrees(x, y, z);
+        }
+    }
+
+    private Optional<Rotations> readRotations(String value)
+    {
+        try
+        {
+            var list = gson.fromJson(value, List.class);
+
+            Function<String, Optional<Float>> parseFloat = s ->
+            {
+                float v = Float.parseFloat(s + "");
+                if (!Float.isFinite(v)) return Optional.empty();
+
+                return Optional.of(v);
+            };
+
+            RotationStore rotationStore = new RotationStore();
+            parseFloat.get(list.get(0)).ifPresent(rotationStore::x);
+
+            if (list.size() > 1)
+                parseFloat.get(list.get(1)).ifPresent(rotationStore::y);
+
+            if (list.size() > 2)
+                parseFloat.get(list.get(2)).ifPresent(rotationStore::z);
+
+            return Optional.of(rotationStore.toRotations());
+        }
+        catch (Throwable ignored)
+        {
+        }
+
+
+        return Optional.empty();
     }
 
     @Override
@@ -63,29 +128,25 @@ public class ArmorStandProperties extends BaseLivingEntityProperties<ArmorStand>
         propertyHandler.set(HAS_BASE_PLATE, armorStand.hasBasePlate());
         propertyHandler.set(SMALL, armorStand.isSmall());
 
-        propertyHandler.set(HEAD_ROTATION, fromRotations(armorStand.getHeadRotations()));
-        propertyHandler.set(BODY_ROTATION, fromRotations(armorStand.getBodyRotations()));
-        propertyHandler.set(LEFT_ARM_ROTATION, fromRotations(armorStand.getLeftArmRotations()));
-        propertyHandler.set(RIGHT_ARM_ROTATION, fromRotations(armorStand.getRightArmRotations()));
-        propertyHandler.set(LEFT_LEG_ROTATION, fromRotations(armorStand.getLeftLegRotations()));
-        propertyHandler.set(RIGHT_LEG_ROTATION, fromRotations(armorStand.getRightLegRotations()));
-    }
-
-    public Vector3f fromRotations(Rotations rotations)
-    {
-        return new Vector3f((float)rotations.x(), (float)rotations.y(), (float)rotations.z());
+        propertyHandler.set(HEAD_ROTATION, armorStand.getHeadRotations());
+        propertyHandler.set(BODY_ROTATION, armorStand.getBodyRotations());
+        propertyHandler.set(LEFT_ARM_ROTATION, armorStand.getLeftArmRotations());
+        propertyHandler.set(RIGHT_ARM_ROTATION, armorStand.getRightArmRotations());
+        propertyHandler.set(LEFT_LEG_ROTATION, armorStand.getLeftLegRotations());
+        propertyHandler.set(RIGHT_LEG_ROTATION, armorStand.getRightLegRotations());
     }
 
     @Override
     protected void setupDefaultProperties(PropertyHandler propertyHandler)
     {
+        propertyHandler.set(SHOW_ARMS, false);
     }
 
     private final Gson gson = new GsonBuilder().create();
 
-    private String vectorToStringArray(Vector3f vec)
+    private String rotationToStringArray(Rotations vec)
     {
-        float[] array = new float[] {vec.x, vec.y, vec.z};
+        float[] array = new float[] {(float)vec.x(), (float)vec.y(), (float)vec.z()};
         return gson.toJson(array);
     }
 
@@ -96,12 +157,12 @@ public class ArmorStandProperties extends BaseLivingEntityProperties<ArmorStand>
         map.put(HAS_BASE_PLATE.id(), propertyHandler.get(HAS_BASE_PLATE).toString().toLowerCase());
         map.put(SMALL.id(), propertyHandler.get(SMALL).toString().toLowerCase());
 
-        propertyHandler.getOptional(HEAD_ROTATION).ifPresent(v -> map.put(HEAD_ROTATION.id(), vectorToStringArray(v)));
-        propertyHandler.getOptional(BODY_ROTATION).ifPresent(v -> map.put(BODY_ROTATION.id(), vectorToStringArray(v)));
-        propertyHandler.getOptional(LEFT_ARM_ROTATION).ifPresent(v -> map.put(LEFT_ARM_ROTATION.id(), vectorToStringArray(v)));
-        propertyHandler.getOptional(RIGHT_ARM_ROTATION).ifPresent(v -> map.put(RIGHT_ARM_ROTATION.id(), vectorToStringArray(v)));
-        propertyHandler.getOptional(LEFT_LEG_ROTATION).ifPresent(v -> map.put(LEFT_LEG_ROTATION.id(), vectorToStringArray(v)));
-        propertyHandler.getOptional(RIGHT_LEG_ROTATION).ifPresent(v -> map.put(RIGHT_LEG_ROTATION.id(), vectorToStringArray(v)));
+        propertyHandler.getOptional(HEAD_ROTATION).ifPresent(v -> map.put(HEAD_ROTATION.id(), rotationToStringArray(v)));
+        propertyHandler.getOptional(BODY_ROTATION).ifPresent(v -> map.put(BODY_ROTATION.id(), rotationToStringArray(v)));
+        propertyHandler.getOptional(LEFT_ARM_ROTATION).ifPresent(v -> map.put(LEFT_ARM_ROTATION.id(), rotationToStringArray(v)));
+        propertyHandler.getOptional(RIGHT_ARM_ROTATION).ifPresent(v -> map.put(RIGHT_ARM_ROTATION.id(), rotationToStringArray(v)));
+        propertyHandler.getOptional(LEFT_LEG_ROTATION).ifPresent(v -> map.put(LEFT_LEG_ROTATION.id(), rotationToStringArray(v)));
+        propertyHandler.getOptional(RIGHT_LEG_ROTATION).ifPresent(v -> map.put(RIGHT_LEG_ROTATION.id(), rotationToStringArray(v)));
 
         super.appendNetworkMap(propertyHandler, map);
     }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/ArmorStandProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/ArmorStandProperties.java
@@ -1,16 +1,38 @@
 package xyz.nifeather.morph.misc.disguiseProperty.values;
 
+import com.github.retrooper.packetevents.util.Vector3f;
+import io.papermc.paper.math.Rotations;
 import it.unimi.dsi.fastutil.Pair;
+import org.bukkit.Rotation;
+import org.bukkit.entity.ArmorStand;
+import org.bukkit.entity.Entity;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import xyz.nifeather.morph.misc.disguiseProperty.PropertyHandler;
 import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
 
-public class ArmorStandProperties extends AbstractProperties
+import java.util.Map;
+
+public class ArmorStandProperties extends BaseLivingEntityProperties<ArmorStand>
 {
     public final SingleProperty<Boolean> SHOW_ARMS = getSingle("armor_stand_show_arms", false).withValidInput("true", "false");
+    public final SingleProperty<Boolean> HAS_BASE_PLATE = getSingle("has_base_plate", true)
+            .withValidInput("true", "false");
+    public final SingleProperty<Boolean> SMALL = getSingle("small", false)
+            .withValidInput("true", "false");
+
+    public final SingleProperty<Vector3f> HEAD_ROTATION = getSingle("head_rotation", Vector3f.zero());
+    public final SingleProperty<Vector3f> BODY_ROTATION = getSingle("body_rotation", Vector3f.zero());
+    public final SingleProperty<Vector3f> RIGHT_ARM_ROTATION = getSingle("right_arm_rotation", Vector3f.zero());
+    public final SingleProperty<Vector3f> LEFT_ARM_ROTATION = getSingle("left_arm_rotation", Vector3f.zero());
+    public final SingleProperty<Vector3f> RIGHT_LEG_ROTATION = getSingle("right_leg_rotation", Vector3f.zero());
+    public final SingleProperty<Vector3f> LEFT_LEG_ROTATION = getSingle("left_leg_rotation", Vector3f.zero());
 
     public ArmorStandProperties()
     {
-        registerSingle(SHOW_ARMS);
+        registerSingle(SHOW_ARMS, HAS_BASE_PLATE, SMALL);
+
+        registerSingle(HEAD_ROTATION, BODY_ROTATION, RIGHT_ARM_ROTATION, LEFT_ARM_ROTATION, RIGHT_LEG_ROTATION, LEFT_LEG_ROTATION);
     }
 
     @Override
@@ -18,7 +40,50 @@ public class ArmorStandProperties extends AbstractProperties
     {
         if (key.equals(SHOW_ARMS.id()))
             return Pair.of(SHOW_ARMS, Boolean.valueOf(value));
+        else if (key.equals(HAS_BASE_PLATE.id()))
+            return Pair.of(HAS_BASE_PLATE, Boolean.valueOf(value));
+        else if (key.equals(SMALL.id()))
+            return Pair.of(SMALL, Boolean.valueOf(value));
 
-        return null;
+        return super.parseSingleInput(key, value);
+    }
+
+    @Override
+    protected @Nullable ArmorStand tryCastEntity(@Nullable Entity targetEntity)
+    {
+        return targetEntity instanceof ArmorStand armorStand ? armorStand : null;
+    }
+
+    @Override
+    public void setupPropertiesFromEntity(PropertyHandler propertyHandler, @NotNull ArmorStand armorStand)
+    {
+        propertyHandler.set(SHOW_ARMS, armorStand.hasArms());
+        propertyHandler.set(HAS_BASE_PLATE, armorStand.hasBasePlate());
+        propertyHandler.set(SMALL, armorStand.isSmall());
+
+        propertyHandler.set(HEAD_ROTATION, fromRotations(armorStand.getHeadRotations()));
+        propertyHandler.set(BODY_ROTATION, fromRotations(armorStand.getBodyRotations()));
+        propertyHandler.set(LEFT_ARM_ROTATION, fromRotations(armorStand.getLeftArmRotations()));
+        propertyHandler.set(RIGHT_ARM_ROTATION, fromRotations(armorStand.getRightArmRotations()));
+        propertyHandler.set(LEFT_LEG_ROTATION, fromRotations(armorStand.getLeftLegRotations()));
+        propertyHandler.set(RIGHT_LEG_ROTATION, fromRotations(armorStand.getRightLegRotations()));
+    }
+
+    public Vector3f fromRotations(Rotations rotations)
+    {
+        return new Vector3f((float)rotations.x(), (float)rotations.y(), (float)rotations.z());
+    }
+
+    @Override
+    protected void setupDefaultProperties(PropertyHandler propertyHandler)
+    {
+    }
+
+    @Override
+    public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
+    {
+        return Map.of(
+                "show_arms", propertyHandler.get(SHOW_ARMS).toString()
+        );
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/ArmorStandProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/ArmorStandProperties.java
@@ -90,9 +90,8 @@ public class ArmorStandProperties extends BaseLivingEntityProperties<ArmorStand>
     }
 
     @Override
-    public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
+    protected void appendNetworkMap(PropertyHandler propertyHandler, Map<String, String> map)
     {
-        var map = new ConcurrentHashMap<String, String>();
         map.put(SHOW_ARMS.id(), propertyHandler.get(SHOW_ARMS).toString().toLowerCase());
         map.put(HAS_BASE_PLATE.id(), propertyHandler.get(HAS_BASE_PLATE).toString().toLowerCase());
         map.put(SMALL.id(), propertyHandler.get(SMALL).toString().toLowerCase());
@@ -104,6 +103,6 @@ public class ArmorStandProperties extends BaseLivingEntityProperties<ArmorStand>
         propertyHandler.getOptional(LEFT_LEG_ROTATION).ifPresent(v -> map.put(LEFT_LEG_ROTATION.id(), vectorToStringArray(v)));
         propertyHandler.getOptional(RIGHT_LEG_ROTATION).ifPresent(v -> map.put(RIGHT_LEG_ROTATION.id(), vectorToStringArray(v)));
 
-        return map;
+        super.appendNetworkMap(propertyHandler, map);
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/ArmorStandProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/ArmorStandProperties.java
@@ -15,18 +15,18 @@ import java.util.Map;
 
 public class ArmorStandProperties extends BaseLivingEntityProperties<ArmorStand>
 {
-    public final SingleProperty<Boolean> SHOW_ARMS = getSingle("armor_stand_show_arms", false).withValidInput("true", "false");
-    public final SingleProperty<Boolean> HAS_BASE_PLATE = getSingle("has_base_plate", true)
+    public final SingleProperty<Boolean> SHOW_ARMS = getSingle("armor_stand/show_arms", false).withValidInput("true", "false");
+    public final SingleProperty<Boolean> HAS_BASE_PLATE = getSingle("armor_stand/has_base_plate", true)
             .withValidInput("true", "false");
-    public final SingleProperty<Boolean> SMALL = getSingle("small", false)
+    public final SingleProperty<Boolean> SMALL = getSingle("armor_stand/small", false)
             .withValidInput("true", "false");
 
-    public final SingleProperty<Vector3f> HEAD_ROTATION = getSingle("head_rotation", Vector3f.zero());
-    public final SingleProperty<Vector3f> BODY_ROTATION = getSingle("body_rotation", Vector3f.zero());
-    public final SingleProperty<Vector3f> RIGHT_ARM_ROTATION = getSingle("right_arm_rotation", Vector3f.zero());
-    public final SingleProperty<Vector3f> LEFT_ARM_ROTATION = getSingle("left_arm_rotation", Vector3f.zero());
-    public final SingleProperty<Vector3f> RIGHT_LEG_ROTATION = getSingle("right_leg_rotation", Vector3f.zero());
-    public final SingleProperty<Vector3f> LEFT_LEG_ROTATION = getSingle("left_leg_rotation", Vector3f.zero());
+    public final SingleProperty<Vector3f> HEAD_ROTATION = getSingle("armor_stand/head_rotation", Vector3f.zero());
+    public final SingleProperty<Vector3f> BODY_ROTATION = getSingle("armor_stand/body_rotation", Vector3f.zero());
+    public final SingleProperty<Vector3f> RIGHT_ARM_ROTATION = getSingle("armor_stand/right_arm_rotation", Vector3f.zero());
+    public final SingleProperty<Vector3f> LEFT_ARM_ROTATION = getSingle("armor_stand/left_arm_rotation", Vector3f.zero());
+    public final SingleProperty<Vector3f> RIGHT_LEG_ROTATION = getSingle("armor_stand/right_leg_rotation", Vector3f.zero());
+    public final SingleProperty<Vector3f> LEFT_LEG_ROTATION = getSingle("armor_stand/left_leg_rotation", Vector3f.zero());
 
     public ArmorStandProperties()
     {
@@ -83,7 +83,7 @@ public class ArmorStandProperties extends BaseLivingEntityProperties<ArmorStand>
     public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
     {
         return Map.of(
-                "show_arms", propertyHandler.get(SHOW_ARMS).toString()
+                SHOW_ARMS.id(), propertyHandler.get(SHOW_ARMS).toString()
         );
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/ArmorStandProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/ArmorStandProperties.java
@@ -1,9 +1,10 @@
 package xyz.nifeather.morph.misc.disguiseProperty.values;
 
 import com.github.retrooper.packetevents.util.Vector3f;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import io.papermc.paper.math.Rotations;
 import it.unimi.dsi.fastutil.Pair;
-import org.bukkit.Rotation;
 import org.bukkit.entity.ArmorStand;
 import org.bukkit.entity.Entity;
 import org.jetbrains.annotations.NotNull;
@@ -12,6 +13,7 @@ import xyz.nifeather.morph.misc.disguiseProperty.PropertyHandler;
 import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
 
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class ArmorStandProperties extends BaseLivingEntityProperties<ArmorStand>
 {
@@ -79,11 +81,29 @@ public class ArmorStandProperties extends BaseLivingEntityProperties<ArmorStand>
     {
     }
 
+    private final Gson gson = new GsonBuilder().create();
+
+    private String vectorToStringArray(Vector3f vec)
+    {
+        float[] array = new float[] {vec.x, vec.y, vec.z};
+        return gson.toJson(array);
+    }
+
     @Override
     public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
     {
-        return Map.of(
-                SHOW_ARMS.id(), propertyHandler.get(SHOW_ARMS).toString()
-        );
+        var map = new ConcurrentHashMap<String, String>();
+        map.put(SHOW_ARMS.id(), propertyHandler.get(SHOW_ARMS).toString().toLowerCase());
+        map.put(HAS_BASE_PLATE.id(), propertyHandler.get(HAS_BASE_PLATE).toString().toLowerCase());
+        map.put(SMALL.id(), propertyHandler.get(SMALL).toString().toLowerCase());
+
+        propertyHandler.getOptional(HEAD_ROTATION).ifPresent(v -> map.put(HEAD_ROTATION.id(), vectorToStringArray(v)));
+        propertyHandler.getOptional(BODY_ROTATION).ifPresent(v -> map.put(BODY_ROTATION.id(), vectorToStringArray(v)));
+        propertyHandler.getOptional(LEFT_ARM_ROTATION).ifPresent(v -> map.put(LEFT_ARM_ROTATION.id(), vectorToStringArray(v)));
+        propertyHandler.getOptional(RIGHT_ARM_ROTATION).ifPresent(v -> map.put(RIGHT_ARM_ROTATION.id(), vectorToStringArray(v)));
+        propertyHandler.getOptional(LEFT_LEG_ROTATION).ifPresent(v -> map.put(LEFT_LEG_ROTATION.id(), vectorToStringArray(v)));
+        propertyHandler.getOptional(RIGHT_LEG_ROTATION).ifPresent(v -> map.put(RIGHT_LEG_ROTATION.id(), vectorToStringArray(v)));
+
+        return map;
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/AxolotlProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/AxolotlProperties.java
@@ -6,6 +6,7 @@ import org.bukkit.entity.Entity;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import xyz.nifeather.morph.misc.disguiseProperty.PropertyHandler;
+import xyz.nifeather.morph.misc.disguiseProperty.PropertyNames;
 import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
 import xyz.nifeather.morph.utilities.DisguiseUtils;
 
@@ -22,7 +23,7 @@ public class AxolotlProperties extends BaseLivingEntityProperties<Axolotl>
             variantMap.put(variant.name().toLowerCase(), variant);
     }
 
-    public final SingleProperty<Axolotl.Variant> VARIANT = getSingle("axolotl/variant", Axolotl.Variant.LUCY)
+    public final SingleProperty<Axolotl.Variant> VARIANT = getSingle(PropertyNames.AXOLOTL_VARIANT, Axolotl.Variant.LUCY)
             .withRandom(Axolotl.Variant.values());
 
     public AxolotlProperties()
@@ -36,7 +37,7 @@ public class AxolotlProperties extends BaseLivingEntityProperties<Axolotl>
     @Override
     protected @Nullable Pair<SingleProperty<?>, Object> parseSingleInput(String key, String value)
     {
-        if (key.equals(VARIANT.id()))
+        if (key.equals(PropertyNames.AXOLOTL_VARIANT))
         {
             var match = variantMap.getOrDefault(value, null);
 

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/AxolotlProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/AxolotlProperties.java
@@ -2,13 +2,17 @@ package xyz.nifeather.morph.misc.disguiseProperty.values;
 
 import it.unimi.dsi.fastutil.Pair;
 import org.bukkit.entity.Axolotl;
+import org.bukkit.entity.Entity;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import xyz.nifeather.morph.misc.disguiseProperty.PropertyHandler;
 import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
+import xyz.nifeather.morph.utilities.DisguiseUtils;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-public class AxolotlProperties extends AbstractProperties
+public class AxolotlProperties extends BaseLivingEntityProperties<Axolotl>
 {
     private final Map<String, Axolotl.Variant> variantMap = new ConcurrentHashMap<>();
 
@@ -40,6 +44,32 @@ public class AxolotlProperties extends AbstractProperties
                 return Pair.of(VARIANT, match);
         }
 
-        return null;
+        return super.parseSingleInput(key, value);
+    }
+
+    @Override
+    protected @Nullable Axolotl tryCastEntity(@Nullable Entity targetEntity)
+    {
+        return targetEntity instanceof Axolotl axolotl ? axolotl : null;
+    }
+
+    @Override
+    public void setupPropertiesFromEntity(PropertyHandler propertyHandler, @NotNull Axolotl axolotl)
+    {
+        propertyHandler.set(VARIANT, axolotl.getVariant());
+    }
+
+    @Override
+    protected void setupDefaultProperties(PropertyHandler propertyHandler)
+    {
+        propertyHandler.set(VARIANT, DisguiseUtils.pick(VARIANT.getRandomValues()));
+    }
+
+    @Override
+    public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
+    {
+        return Map.of(
+                "variant", propertyHandler.get(VARIANT).name().toLowerCase()
+        );
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/AxolotlProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/AxolotlProperties.java
@@ -66,10 +66,9 @@ public class AxolotlProperties extends BaseLivingEntityProperties<Axolotl>
     }
 
     @Override
-    public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
+    protected void appendNetworkMap(PropertyHandler propertyHandler, Map<String, String> map)
     {
-        return Map.of(
-                VARIANT.id(), propertyHandler.get(VARIANT).name().toLowerCase()
-        );
+        super.appendNetworkMap(propertyHandler, map);
+        map.put(VARIANT.id(), propertyHandler.get(VARIANT).name().toLowerCase());
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/AxolotlProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/AxolotlProperties.java
@@ -22,7 +22,7 @@ public class AxolotlProperties extends BaseLivingEntityProperties<Axolotl>
             variantMap.put(variant.name().toLowerCase(), variant);
     }
 
-    public final SingleProperty<Axolotl.Variant> VARIANT = getSingle("axolotl_color", Axolotl.Variant.LUCY)
+    public final SingleProperty<Axolotl.Variant> VARIANT = getSingle("axolotl/variant", Axolotl.Variant.LUCY)
             .withRandom(Axolotl.Variant.values());
 
     public AxolotlProperties()
@@ -69,7 +69,7 @@ public class AxolotlProperties extends BaseLivingEntityProperties<Axolotl>
     public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
     {
         return Map.of(
-                "variant", propertyHandler.get(VARIANT).name().toLowerCase()
+                VARIANT.id(), propertyHandler.get(VARIANT).name().toLowerCase()
         );
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/BaseLivingEntityProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/BaseLivingEntityProperties.java
@@ -11,12 +11,12 @@ import xyz.nifeather.morph.utilities.MathUtils;
 
 public abstract class BaseLivingEntityProperties<E extends Entity> extends AbstractProperties<E>
 {
-    public final SingleProperty<Component> CUSTOM_NAME = getSingle("custom_name", Component.empty());
+    public final SingleProperty<Component> CUSTOM_NAME = getSingle("entity/custom_name", Component.empty());
 
-    public final SingleProperty<Boolean> CUSTOM_NAME_VISIBLE = getSingle("custom_name_visible", false)
+    public final SingleProperty<Boolean> CUSTOM_NAME_VISIBLE = getSingle("entity/custom_name_visible", false)
             .withValidInput("true", "false");
 
-    public final SingleProperty<Integer> STUCKED_ARROWS = getSingle("stucked_arrows", 0);
+    public final SingleProperty<Integer> STUCKED_ARROWS = getSingle("entity/stucked_arrows", 0);
 
     public BaseLivingEntityProperties()
     {

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/BaseLivingEntityProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/BaseLivingEntityProperties.java
@@ -4,10 +4,14 @@ import it.unimi.dsi.fastutil.Pair;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.minimessage.MiniMessage;
+import net.kyori.adventure.text.serializer.json.JSONComponentSerializer;
 import org.bukkit.entity.Entity;
 import org.jetbrains.annotations.Nullable;
+import xyz.nifeather.morph.misc.disguiseProperty.PropertyHandler;
 import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
 import xyz.nifeather.morph.utilities.MathUtils;
+
+import java.util.Map;
 
 public abstract class BaseLivingEntityProperties<E extends Entity> extends AbstractProperties<E>
 {
@@ -56,5 +60,16 @@ public abstract class BaseLivingEntityProperties<E extends Entity> extends Abstr
         }
 
         return null;
+    }
+
+    @Override
+    protected void appendNetworkMap(PropertyHandler propertyHandler, Map<String, String> map)
+    {
+        propertyHandler.getOptional(CUSTOM_NAME).ifPresent(component ->
+                map.put(CUSTOM_NAME.id(), JSONComponentSerializer.json().serialize(component)));
+
+        propertyHandler.getOptional(CUSTOM_NAME_VISIBLE).ifPresent(v -> map.put(CUSTOM_NAME_VISIBLE.id(), v.toString().toLowerCase()));
+
+        propertyHandler.getOptional(STUCKED_ARROWS).ifPresent(v -> map.put(STUCKED_ARROWS.id(), v.toString()));
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/BaseLivingEntityProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/BaseLivingEntityProperties.java
@@ -8,6 +8,7 @@ import net.kyori.adventure.text.serializer.json.JSONComponentSerializer;
 import org.bukkit.entity.Entity;
 import org.jetbrains.annotations.Nullable;
 import xyz.nifeather.morph.misc.disguiseProperty.PropertyHandler;
+import xyz.nifeather.morph.misc.disguiseProperty.PropertyNames;
 import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
 import xyz.nifeather.morph.utilities.MathUtils;
 
@@ -15,12 +16,12 @@ import java.util.Map;
 
 public abstract class BaseLivingEntityProperties<E extends Entity> extends AbstractProperties<E>
 {
-    public final SingleProperty<Component> CUSTOM_NAME = getSingle("entity/custom_name", Component.empty());
+    public final SingleProperty<Component> CUSTOM_NAME = getSingle(PropertyNames.ENTITY_CUSTOM_NAME, Component.empty());
 
-    public final SingleProperty<Boolean> CUSTOM_NAME_VISIBLE = getSingle("entity/custom_name_visible", false)
+    public final SingleProperty<Boolean> CUSTOM_NAME_VISIBLE = getSingle(PropertyNames.ENTITY_CUSTOM_NAME_VISIBLE, false)
             .withValidInput("true", "false");
 
-    public final SingleProperty<Integer> STUCKED_ARROWS = getSingle("entity/stucked_arrows", 0);
+    public final SingleProperty<Integer> STUCKED_ARROWS = getSingle(PropertyNames.ENTITY_ARROW_COUNT, 0);
 
     public BaseLivingEntityProperties()
     {
@@ -33,7 +34,7 @@ public abstract class BaseLivingEntityProperties<E extends Entity> extends Abstr
     @Override
     protected @Nullable Pair<SingleProperty<?>, Object> parseSingleInput(String key, String value)
     {
-        if (key.equals(CUSTOM_NAME.id()))
+        if (key.equals(PropertyNames.ENTITY_CUSTOM_NAME))
         {
             try
             {
@@ -49,11 +50,11 @@ public abstract class BaseLivingEntityProperties<E extends Entity> extends Abstr
                 return Pair.of(CUSTOM_NAME, minimessageFormatFail);
             }
         }
-        else if (key.equals(CUSTOM_NAME_VISIBLE.id()))
+        else if (key.equals(PropertyNames.ENTITY_CUSTOM_NAME_VISIBLE))
         {
             return Pair.of(CUSTOM_NAME_VISIBLE, Boolean.parseBoolean(value));
         }
-        else if (key.equals(STUCKED_ARROWS.id()))
+        else if (key.equals(PropertyNames.ENTITY_ARROW_COUNT))
         {
             int val = MathUtils.clamp(0, 100, MathUtils.parseIntOr(value, 0));
             return Pair.of(STUCKED_ARROWS, val);

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/BaseLivingEntityProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/BaseLivingEntityProperties.java
@@ -1,0 +1,60 @@
+package xyz.nifeather.morph.misc.disguiseProperty.values;
+
+import it.unimi.dsi.fastutil.Pair;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.TextComponent;
+import net.kyori.adventure.text.minimessage.MiniMessage;
+import org.bukkit.entity.Entity;
+import org.jetbrains.annotations.Nullable;
+import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
+import xyz.nifeather.morph.utilities.MathUtils;
+
+public abstract class BaseLivingEntityProperties<E extends Entity> extends AbstractProperties<E>
+{
+    public final SingleProperty<Component> CUSTOM_NAME = getSingle("custom_name", Component.empty());
+
+    public final SingleProperty<Boolean> CUSTOM_NAME_VISIBLE = getSingle("custom_name_visible", false)
+            .withValidInput("true", "false");
+
+    public final SingleProperty<Integer> STUCKED_ARROWS = getSingle("stucked_arrows", 0);
+
+    public BaseLivingEntityProperties()
+    {
+        registerSingle(CUSTOM_NAME, CUSTOM_NAME_VISIBLE, STUCKED_ARROWS);
+    }
+
+    private static final Component minimessageFormatFail = Component.text("MiniMessage format error");
+    private static final Component minimessageCastFail = Component.text("MiniMessage cast error");
+
+    @Override
+    protected @Nullable Pair<SingleProperty<?>, Object> parseSingleInput(String key, String value)
+    {
+        if (key.equals(CUSTOM_NAME.id()))
+        {
+            try
+            {
+                var component = (TextComponent) MiniMessage.miniMessage().deserialize(value);
+                return Pair.of(CUSTOM_NAME, component);
+            }
+            catch (ClassCastException e)
+            {
+                return Pair.of(CUSTOM_NAME, minimessageCastFail);
+            }
+            catch (Throwable t)
+            {
+                return Pair.of(CUSTOM_NAME, minimessageFormatFail);
+            }
+        }
+        else if (key.equals(CUSTOM_NAME_VISIBLE.id()))
+        {
+            return Pair.of(CUSTOM_NAME_VISIBLE, Boolean.parseBoolean(value));
+        }
+        else if (key.equals(STUCKED_ARROWS.id()))
+        {
+            int val = MathUtils.clamp(0, 100, MathUtils.parseIntOr(value, 0));
+            return Pair.of(STUCKED_ARROWS, val);
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/CatProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/CatProperties.java
@@ -8,6 +8,7 @@ import org.bukkit.entity.Entity;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import xyz.nifeather.morph.misc.disguiseProperty.PropertyHandler;
+import xyz.nifeather.morph.misc.disguiseProperty.PropertyNames;
 import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
 import xyz.nifeather.morph.utilities.DisguiseUtils;
 import xyz.nifeather.morph.utilities.Uuids;
@@ -26,8 +27,8 @@ public class CatProperties extends BaseLivingEntityProperties<Cat>
             variantMap.put(variant.key().asString(), variant);
     }
 
-    public final SingleProperty<Cat.Type> CAT_VARIANT = getSingle("cat/variant", Cat.Type.TABBY);
-    public final SingleProperty<UUID> OWNER = getSingle("cat/owner", Uuids.NIL_UUID);
+    public final SingleProperty<Cat.Type> CAT_VARIANT = getSingle(PropertyNames.CAT_VARIANT, Cat.Type.TABBY);
+    public final SingleProperty<UUID> OWNER = getSingle(PropertyNames.CAT_OWNER, Uuids.NIL_UUID);
 
     public CatProperties()
     {
@@ -43,31 +44,36 @@ public class CatProperties extends BaseLivingEntityProperties<Cat>
     @Override
     protected @Nullable Pair<SingleProperty<?>, Object> parseSingleInput(String key, String value)
     {
-        if (key.equals(CAT_VARIANT.id()))
+        return switch (key)
         {
-            var match = variantMap.getOrDefault(value, null);
-
-            if (match != null)
-                return Pair.of(CAT_VARIANT, match);
-        }
-
-        if (key.equals(OWNER.id()))
-        {
-            UUID uuid = null;
-
-            try
+            case PropertyNames.CAT_VARIANT ->
             {
-                uuid = UUID.fromString(value);
-                return Pair.of(OWNER, uuid);
-            }
-            catch (Throwable ignored)
-            {
+                var match = variantMap.getOrDefault(value, null);
+
+                if (match != null)
+                    yield Pair.of(CAT_VARIANT, match);
+                else
+                    yield null;
             }
 
-            return null;
-        }
+            case PropertyNames.CAT_OWNER ->
+            {
+                UUID uuid = null;
 
-        return super.parseSingleInput(key, value);
+                try
+                {
+                    uuid = UUID.fromString(value);
+                    yield Pair.of(OWNER, uuid);
+                }
+                catch (Throwable ignored)
+                {
+                }
+
+                yield null;
+            }
+
+            default -> super.parseSingleInput(key, value);
+        };
     }
 
     @Override

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/CatProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/CatProperties.java
@@ -92,10 +92,9 @@ public class CatProperties extends BaseLivingEntityProperties<Cat>
     }
 
     @Override
-    public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
+    protected void appendNetworkMap(PropertyHandler propertyHandler, Map<String, String> map)
     {
-        return Map.of(
-                CAT_VARIANT.id(), propertyHandler.get(CAT_VARIANT).key().asString()
-        );
+        super.appendNetworkMap(propertyHandler, map);
+        map.put(CAT_VARIANT.id(), propertyHandler.get(CAT_VARIANT).key().asString());
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/CatProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/CatProperties.java
@@ -26,8 +26,8 @@ public class CatProperties extends BaseLivingEntityProperties<Cat>
             variantMap.put(variant.key().asString(), variant);
     }
 
-    public final SingleProperty<Cat.Type> CAT_VARIANT = getSingle("cat_variant", Cat.Type.TABBY);
-    public final SingleProperty<UUID> OWNER = getSingle("owner", Uuids.NIL_UUID);
+    public final SingleProperty<Cat.Type> CAT_VARIANT = getSingle("cat/variant", Cat.Type.TABBY);
+    public final SingleProperty<UUID> OWNER = getSingle("cat/owner", Uuids.NIL_UUID);
 
     public CatProperties()
     {
@@ -95,7 +95,7 @@ public class CatProperties extends BaseLivingEntityProperties<Cat>
     public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
     {
         return Map.of(
-                "variant", propertyHandler.get(CAT_VARIANT).key().asString()
+                CAT_VARIANT.id(), propertyHandler.get(CAT_VARIANT).key().asString()
         );
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/CatProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/CatProperties.java
@@ -4,13 +4,19 @@ import io.papermc.paper.registry.RegistryAccess;
 import io.papermc.paper.registry.RegistryKey;
 import it.unimi.dsi.fastutil.Pair;
 import org.bukkit.entity.Cat;
+import org.bukkit.entity.Entity;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import xyz.nifeather.morph.misc.disguiseProperty.PropertyHandler;
 import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
+import xyz.nifeather.morph.utilities.DisguiseUtils;
+import xyz.nifeather.morph.utilities.Uuids;
 
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
-public class CatProperties extends AbstractProperties
+public class CatProperties extends BaseLivingEntityProperties<Cat>
 {
     private final Map<String, Cat.Type> variantMap = new ConcurrentHashMap<>();
 
@@ -21,6 +27,7 @@ public class CatProperties extends AbstractProperties
     }
 
     public final SingleProperty<Cat.Type> CAT_VARIANT = getSingle("cat_variant", Cat.Type.TABBY);
+    public final SingleProperty<UUID> OWNER = getSingle("owner", Uuids.NIL_UUID);
 
     public CatProperties()
     {
@@ -29,7 +36,7 @@ public class CatProperties extends AbstractProperties
                 .withRandom(variantMap.values());
 
         registerSingle(
-                CAT_VARIANT
+                CAT_VARIANT, OWNER
         );
     }
 
@@ -44,6 +51,51 @@ public class CatProperties extends AbstractProperties
                 return Pair.of(CAT_VARIANT, match);
         }
 
-        return null;
+        if (key.equals(OWNER.id()))
+        {
+            UUID uuid = null;
+
+            try
+            {
+                uuid = UUID.fromString(value);
+                return Pair.of(OWNER, uuid);
+            }
+            catch (Throwable ignored)
+            {
+            }
+
+            return null;
+        }
+
+        return super.parseSingleInput(key, value);
+    }
+
+    @Override
+    protected @Nullable Cat tryCastEntity(@Nullable Entity targetEntity)
+    {
+        return targetEntity instanceof Cat cat ? cat : null;
+    }
+
+    @Override
+    protected void setupPropertiesFromEntity(PropertyHandler propertyHandler, @NotNull Cat cat)
+    {
+        propertyHandler.set(CAT_VARIANT, cat.getCatType());
+
+        if (cat.getOwnerUniqueId() != null)
+            propertyHandler.set(OWNER, cat.getOwnerUniqueId());
+    }
+
+    @Override
+    protected void setupDefaultProperties(PropertyHandler propertyHandler)
+    {
+        propertyHandler.set(CAT_VARIANT, DisguiseUtils.pick(CAT_VARIANT.getRandomValues()));
+    }
+
+    @Override
+    public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
+    {
+        return Map.of(
+                "variant", propertyHandler.get(CAT_VARIANT).key().asString()
+        );
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/ChickenProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/ChickenProperties.java
@@ -4,13 +4,17 @@ import io.papermc.paper.registry.RegistryAccess;
 import io.papermc.paper.registry.RegistryKey;
 import it.unimi.dsi.fastutil.Pair;
 import org.bukkit.entity.Chicken;
+import org.bukkit.entity.Entity;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import xyz.nifeather.morph.misc.disguiseProperty.PropertyHandler;
 import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
+import xyz.nifeather.morph.utilities.DisguiseUtils;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-public class ChickenProperties extends AbstractProperties
+public class ChickenProperties extends BaseLivingEntityProperties<Chicken>
 {
     private final Map<String, Chicken.Variant> variantMap = new ConcurrentHashMap<>();
 
@@ -44,6 +48,32 @@ public class ChickenProperties extends AbstractProperties
                 return Pair.of(VARIANT, match);
         }
 
-        return null;
+        return super.parseSingleInput(key, value);
+    }
+
+    @Override
+    protected @Nullable Chicken tryCastEntity(@Nullable Entity targetEntity)
+    {
+        return targetEntity instanceof Chicken chicken ? chicken : null;
+    }
+
+    @Override
+    protected void setupPropertiesFromEntity(PropertyHandler propertyHandler, @NotNull Chicken chicken)
+    {
+        propertyHandler.set(VARIANT, chicken.getVariant());
+    }
+
+    @Override
+    protected void setupDefaultProperties(PropertyHandler propertyHandler)
+    {
+        propertyHandler.set(VARIANT, DisguiseUtils.pick(VARIANT.getRandomValues()));
+    }
+
+    @Override
+    public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
+    {
+        return Map.of(
+                "variant", propertyHandler.get(VARIANT).key().asString()
+        );
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/ChickenProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/ChickenProperties.java
@@ -70,10 +70,9 @@ public class ChickenProperties extends BaseLivingEntityProperties<Chicken>
     }
 
     @Override
-    public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
+    protected void appendNetworkMap(PropertyHandler propertyHandler, Map<String, String> map)
     {
-        return Map.of(
-                VARIANT.id(), propertyHandler.get(VARIANT).key().asString()
-        );
+        super.appendNetworkMap(propertyHandler, map);
+        map.put(VARIANT.id(), propertyHandler.get(VARIANT).key().asString());
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/ChickenProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/ChickenProperties.java
@@ -8,6 +8,7 @@ import org.bukkit.entity.Entity;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import xyz.nifeather.morph.misc.disguiseProperty.PropertyHandler;
+import xyz.nifeather.morph.misc.disguiseProperty.PropertyNames;
 import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
 import xyz.nifeather.morph.utilities.DisguiseUtils;
 
@@ -24,7 +25,7 @@ public class ChickenProperties extends BaseLivingEntityProperties<Chicken>
             variantMap.put(variant.key().asString(), variant);
     }
 
-    public final SingleProperty<Chicken.Variant> VARIANT = getSingle("chicken/variant", Chicken.Variant.TEMPERATE);
+    public final SingleProperty<Chicken.Variant> VARIANT = getSingle(PropertyNames.CHICKEN_VARIANT, Chicken.Variant.TEMPERATE);
 
     public ChickenProperties()
     {
@@ -40,7 +41,7 @@ public class ChickenProperties extends BaseLivingEntityProperties<Chicken>
     @Override
     protected @Nullable Pair<SingleProperty<?>, Object> parseSingleInput(String key, String value)
     {
-        if (key.equals(VARIANT.id()))
+        if (key.equals(PropertyNames.CHICKEN_VARIANT))
         {
             var match = variantMap.getOrDefault(value, null);
 

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/ChickenProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/ChickenProperties.java
@@ -24,7 +24,7 @@ public class ChickenProperties extends BaseLivingEntityProperties<Chicken>
             variantMap.put(variant.key().asString(), variant);
     }
 
-    public final SingleProperty<Chicken.Variant> VARIANT = getSingle("chicken_variant", Chicken.Variant.TEMPERATE);
+    public final SingleProperty<Chicken.Variant> VARIANT = getSingle("chicken/variant", Chicken.Variant.TEMPERATE);
 
     public ChickenProperties()
     {
@@ -73,7 +73,7 @@ public class ChickenProperties extends BaseLivingEntityProperties<Chicken>
     public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
     {
         return Map.of(
-                "variant", propertyHandler.get(VARIANT).key().asString()
+                VARIANT.id(), propertyHandler.get(VARIANT).key().asString()
         );
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/CowProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/CowProperties.java
@@ -4,13 +4,17 @@ import io.papermc.paper.registry.RegistryAccess;
 import io.papermc.paper.registry.RegistryKey;
 import it.unimi.dsi.fastutil.Pair;
 import org.bukkit.entity.Cow;
+import org.bukkit.entity.Entity;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import xyz.nifeather.morph.misc.disguiseProperty.PropertyHandler;
 import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
+import xyz.nifeather.morph.utilities.DisguiseUtils;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-public class CowProperties extends AbstractProperties
+public class CowProperties extends BaseLivingEntityProperties<Cow>
 {
     private final Map<String, Cow.Variant> variantMap = new ConcurrentHashMap<>();
 
@@ -39,6 +43,32 @@ public class CowProperties extends AbstractProperties
                 return Pair.of(VARIANT, match);
         }
 
-        return null;
+        return super.parseSingleInput(key, value);
+    }
+
+    @Override
+    protected @Nullable Cow tryCastEntity(@Nullable Entity targetEntity)
+    {
+        return targetEntity instanceof Cow cow ? cow : null;
+    }
+
+    @Override
+    protected void setupPropertiesFromEntity(PropertyHandler propertyHandler, @NotNull Cow cow)
+    {
+        propertyHandler.set(VARIANT, cow.getVariant());
+    }
+
+    @Override
+    protected void setupDefaultProperties(PropertyHandler propertyHandler)
+    {
+        propertyHandler.set(VARIANT, DisguiseUtils.pick(VARIANT.getRandomValues()));
+    }
+
+    @Override
+    public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
+    {
+        return Map.of(
+                "variant", propertyHandler.get(VARIANT).key().asString()
+        );
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/CowProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/CowProperties.java
@@ -25,7 +25,7 @@ public class CowProperties extends BaseLivingEntityProperties<Cow>
         for (Cow.Variant variant : RegistryAccess.registryAccess().getRegistry(RegistryKey.COW_VARIANT))
             variantMap.put(variant.key().asString(), variant);
 
-        VARIANT = getSingle("cow_variant", Cow.Variant.TEMPERATE)
+        VARIANT = getSingle("cow/variant", Cow.Variant.TEMPERATE)
                 .withRandom(variantMap.values())
                 .withValidInput(variantMap.keySet());
 
@@ -68,7 +68,7 @@ public class CowProperties extends BaseLivingEntityProperties<Cow>
     public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
     {
         return Map.of(
-                "variant", propertyHandler.get(VARIANT).key().asString()
+                VARIANT.id(), propertyHandler.get(VARIANT).key().asString()
         );
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/CowProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/CowProperties.java
@@ -65,10 +65,9 @@ public class CowProperties extends BaseLivingEntityProperties<Cow>
     }
 
     @Override
-    public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
+    protected void appendNetworkMap(PropertyHandler propertyHandler, Map<String, String> map)
     {
-        return Map.of(
-                VARIANT.id(), propertyHandler.get(VARIANT).key().asString()
-        );
+        super.appendNetworkMap(propertyHandler, map);
+        map.put(VARIANT.id(), propertyHandler.get(VARIANT).key().asString());
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/CowProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/CowProperties.java
@@ -8,6 +8,7 @@ import org.bukkit.entity.Entity;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import xyz.nifeather.morph.misc.disguiseProperty.PropertyHandler;
+import xyz.nifeather.morph.misc.disguiseProperty.PropertyNames;
 import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
 import xyz.nifeather.morph.utilities.DisguiseUtils;
 
@@ -25,7 +26,7 @@ public class CowProperties extends BaseLivingEntityProperties<Cow>
         for (Cow.Variant variant : RegistryAccess.registryAccess().getRegistry(RegistryKey.COW_VARIANT))
             variantMap.put(variant.key().asString(), variant);
 
-        VARIANT = getSingle("cow/variant", Cow.Variant.TEMPERATE)
+        VARIANT = getSingle(PropertyNames.COW_VARIANT, Cow.Variant.TEMPERATE)
                 .withRandom(variantMap.values())
                 .withValidInput(variantMap.keySet());
 
@@ -35,7 +36,7 @@ public class CowProperties extends BaseLivingEntityProperties<Cow>
     @Override
     protected @Nullable Pair<SingleProperty<?>, Object> parseSingleInput(String key, String value)
     {
-        if (key.equals(VARIANT.id()))
+        if (key.equals(PropertyNames.COW_VARIANT))
         {
             var match = variantMap.getOrDefault(value, null);
 

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/CreeperProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/CreeperProperties.java
@@ -6,6 +6,7 @@ import org.bukkit.entity.Entity;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import xyz.nifeather.morph.misc.disguiseProperty.PropertyHandler;
+import xyz.nifeather.morph.misc.disguiseProperty.PropertyNames;
 import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
 import xyz.nifeather.morph.utilities.DisguiseUtils;
 
@@ -13,7 +14,7 @@ import java.util.Map;
 
 public class CreeperProperties extends BaseLivingEntityProperties<Creeper>
 {
-    public final SingleProperty<Boolean> CHARGED = getSingle("creeper/charged", false)
+    public final SingleProperty<Boolean> CHARGED = getSingle(PropertyNames.CREEPER_CHARGED, false)
             .withRandom(false, false, false, true)
             .withValidInput("true", "false");
 
@@ -25,7 +26,7 @@ public class CreeperProperties extends BaseLivingEntityProperties<Creeper>
     @Override
     protected @Nullable Pair<SingleProperty<?>, Object> parseSingleInput(String key, String value)
     {
-        if (key.equals(CHARGED.id()))
+        if (key.equals(PropertyNames.CREEPER_CHARGED))
             return Pair.of(CHARGED, Boolean.valueOf(value));
 
         return super.parseSingleInput(key, value);

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/CreeperProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/CreeperProperties.java
@@ -1,10 +1,17 @@
 package xyz.nifeather.morph.misc.disguiseProperty.values;
 
 import it.unimi.dsi.fastutil.Pair;
+import org.bukkit.entity.Creeper;
+import org.bukkit.entity.Entity;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import xyz.nifeather.morph.misc.disguiseProperty.PropertyHandler;
 import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
+import xyz.nifeather.morph.utilities.DisguiseUtils;
 
-public class CreeperProperties extends AbstractProperties
+import java.util.Map;
+
+public class CreeperProperties extends BaseLivingEntityProperties<Creeper>
 {
     public final SingleProperty<Boolean> CHARGED = getSingle("creeper_charged", false)
             .withRandom(false, false, false, true)
@@ -21,6 +28,32 @@ public class CreeperProperties extends AbstractProperties
         if (key.equals(CHARGED.id()))
             return Pair.of(CHARGED, Boolean.valueOf(value));
 
-        return null;
+        return super.parseSingleInput(key, value);
+    }
+
+    @Override
+    protected @Nullable Creeper tryCastEntity(@Nullable Entity targetEntity)
+    {
+        return targetEntity instanceof Creeper creeper ? creeper : null;
+    }
+
+    @Override
+    protected void setupPropertiesFromEntity(PropertyHandler propertyHandler, @NotNull Creeper creeper)
+    {
+        propertyHandler.set(CHARGED, creeper.isPowered());
+    }
+
+    @Override
+    protected void setupDefaultProperties(PropertyHandler propertyHandler)
+    {
+        propertyHandler.set(CHARGED, DisguiseUtils.pick(CHARGED.getRandomValues()));
+    }
+
+    @Override
+    public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
+    {
+        return Map.of(
+                "charged", propertyHandler.get(CHARGED).toString().toLowerCase()
+        );
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/CreeperProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/CreeperProperties.java
@@ -13,7 +13,7 @@ import java.util.Map;
 
 public class CreeperProperties extends BaseLivingEntityProperties<Creeper>
 {
-    public final SingleProperty<Boolean> CHARGED = getSingle("creeper_charged", false)
+    public final SingleProperty<Boolean> CHARGED = getSingle("creeper/charged", false)
             .withRandom(false, false, false, true)
             .withValidInput("true", "false");
 
@@ -53,7 +53,7 @@ public class CreeperProperties extends BaseLivingEntityProperties<Creeper>
     public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
     {
         return Map.of(
-                "charged", propertyHandler.get(CHARGED).toString().toLowerCase()
+                CHARGED.id(), propertyHandler.get(CHARGED).toString().toLowerCase()
         );
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/CreeperProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/CreeperProperties.java
@@ -50,10 +50,9 @@ public class CreeperProperties extends BaseLivingEntityProperties<Creeper>
     }
 
     @Override
-    public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
+    protected void appendNetworkMap(PropertyHandler propertyHandler, Map<String, String> map)
     {
-        return Map.of(
-                CHARGED.id(), propertyHandler.get(CHARGED).toString().toLowerCase()
-        );
+        super.appendNetworkMap(propertyHandler, map);
+        map.put(CHARGED.id(), propertyHandler.get(CHARGED).toString().toLowerCase());
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/DefaultProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/DefaultProperties.java
@@ -1,14 +1,35 @@
 package xyz.nifeather.morph.misc.disguiseProperty.values;
 
 import it.unimi.dsi.fastutil.Pair;
+import org.bukkit.entity.Entity;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import xyz.nifeather.morph.misc.disguiseProperty.PropertyHandler;
 import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
 
-public class DefaultProperties extends AbstractProperties
+import java.util.Map;
+
+public class DefaultProperties extends BaseLivingEntityProperties<Entity>
 {
     @Override
-    protected @Nullable Pair<SingleProperty<?>, Object> parseSingleInput(String key, String value)
+    protected @Nullable Entity tryCastEntity(@Nullable Entity targetEntity)
     {
         return null;
+    }
+
+    @Override
+    protected void setupPropertiesFromEntity(PropertyHandler propertyHandler, @NotNull Entity targetEntity)
+    {
+    }
+
+    @Override
+    protected void setupDefaultProperties(PropertyHandler propertyHandler)
+    {
+    }
+
+    @Override
+    public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
+    {
+        return Map.of();
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/EnderDragonProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/EnderDragonProperties.java
@@ -1,6 +1,7 @@
 package xyz.nifeather.morph.misc.disguiseProperty.values;
 
 import it.unimi.dsi.fastutil.Pair;
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import org.bukkit.entity.EnderDragon;
 import org.bukkit.entity.Entity;
 import org.jetbrains.annotations.NotNull;
@@ -8,11 +9,12 @@ import org.jetbrains.annotations.Nullable;
 import xyz.nifeather.morph.misc.disguiseProperty.PropertyHandler;
 import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
 
+import java.util.List;
 import java.util.Map;
 
 public class EnderDragonProperties extends BaseLivingEntityProperties<EnderDragon>
 {
-    public final SingleProperty<Integer> DRAGON_PHASE = getSingle("dragon_phase", 10);
+    public final SingleProperty<Integer> DRAGON_PHASE = getSingle("ender_dragon/dragon_phase", 10);
 
     public EnderDragonProperties()
     {
@@ -48,7 +50,7 @@ public class EnderDragonProperties extends BaseLivingEntityProperties<EnderDrago
     public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
     {
         return Map.of(
-                "dragon_phase", propertyHandler.get(DRAGON_PHASE) + ""
+                DRAGON_PHASE.id(), propertyHandler.get(DRAGON_PHASE) + ""
         );
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/EnderDragonProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/EnderDragonProperties.java
@@ -7,6 +7,7 @@ import org.bukkit.entity.Entity;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import xyz.nifeather.morph.misc.disguiseProperty.PropertyHandler;
+import xyz.nifeather.morph.misc.disguiseProperty.PropertyNames;
 import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
 
 import java.util.List;
@@ -14,7 +15,7 @@ import java.util.Map;
 
 public class EnderDragonProperties extends BaseLivingEntityProperties<EnderDragon>
 {
-    public final SingleProperty<Integer> DRAGON_PHASE = getSingle("ender_dragon/dragon_phase", 10);
+    public final SingleProperty<Integer> DRAGON_PHASE = getSingle(PropertyNames.ENDER_DRAGON_DRAGON_PHASE, 10);
 
     public EnderDragonProperties()
     {
@@ -24,7 +25,7 @@ public class EnderDragonProperties extends BaseLivingEntityProperties<EnderDrago
     @Override
     protected @Nullable Pair<SingleProperty<?>, Object> parseSingleInput(String key, String value)
     {
-        if (key.equals(DRAGON_PHASE.id()))
+        if (key.equals(PropertyNames.ENDER_DRAGON_DRAGON_PHASE))
             return Pair.of(DRAGON_PHASE, Math.clamp(Integer.parseInt(value), 0, 10));
 
         return super.parseSingleInput(key, value);

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/EnderDragonProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/EnderDragonProperties.java
@@ -47,10 +47,9 @@ public class EnderDragonProperties extends BaseLivingEntityProperties<EnderDrago
     }
 
     @Override
-    public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
+    protected void appendNetworkMap(PropertyHandler propertyHandler, Map<String, String> map)
     {
-        return Map.of(
-                DRAGON_PHASE.id(), propertyHandler.get(DRAGON_PHASE) + ""
-        );
+        super.appendNetworkMap(propertyHandler, map);
+        map.put(DRAGON_PHASE.id(), propertyHandler.get(DRAGON_PHASE) + "");
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/EnderDragonProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/EnderDragonProperties.java
@@ -1,10 +1,16 @@
 package xyz.nifeather.morph.misc.disguiseProperty.values;
 
 import it.unimi.dsi.fastutil.Pair;
+import org.bukkit.entity.EnderDragon;
+import org.bukkit.entity.Entity;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import xyz.nifeather.morph.misc.disguiseProperty.PropertyHandler;
 import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
 
-public class EnderDragonProperties extends AbstractProperties
+import java.util.Map;
+
+public class EnderDragonProperties extends BaseLivingEntityProperties<EnderDragon>
 {
     public final SingleProperty<Integer> DRAGON_PHASE = getSingle("dragon_phase", 10);
 
@@ -19,6 +25,30 @@ public class EnderDragonProperties extends AbstractProperties
         if (key.equals(DRAGON_PHASE.id()))
             return Pair.of(DRAGON_PHASE, Math.clamp(Integer.parseInt(value), 0, 10));
 
-        return null;
+        return super.parseSingleInput(key, value);
+    }
+
+    @Override
+    protected @Nullable EnderDragon tryCastEntity(@Nullable Entity targetEntity)
+    {
+        return targetEntity instanceof EnderDragon enderDragon ? enderDragon : null;
+    }
+
+    @Override
+    protected void setupPropertiesFromEntity(PropertyHandler propertyHandler, @NotNull EnderDragon dragon)
+    {
+    }
+
+    @Override
+    protected void setupDefaultProperties(PropertyHandler propertyHandler)
+    {
+    }
+
+    @Override
+    public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
+    {
+        return Map.of(
+                "dragon_phase", propertyHandler.get(DRAGON_PHASE) + ""
+        );
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/FallbackProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/FallbackProperties.java
@@ -24,10 +24,4 @@ public class FallbackProperties extends BaseLivingEntityProperties<Entity>
     protected void setupDefaultProperties(PropertyHandler propertyHandler)
     {
     }
-
-    @Override
-    public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
-    {
-        return Map.of();
-    }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/FallbackProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/FallbackProperties.java
@@ -1,15 +1,13 @@
 package xyz.nifeather.morph.misc.disguiseProperty.values;
 
-import it.unimi.dsi.fastutil.Pair;
 import org.bukkit.entity.Entity;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import xyz.nifeather.morph.misc.disguiseProperty.PropertyHandler;
-import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
 
 import java.util.Map;
 
-public class DefaultProperties extends BaseLivingEntityProperties<Entity>
+public class FallbackProperties extends BaseLivingEntityProperties<Entity>
 {
     @Override
     protected @Nullable Entity tryCastEntity(@Nullable Entity targetEntity)

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/FoxProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/FoxProperties.java
@@ -6,6 +6,7 @@ import org.bukkit.entity.Fox;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import xyz.nifeather.morph.misc.disguiseProperty.PropertyHandler;
+import xyz.nifeather.morph.misc.disguiseProperty.PropertyNames;
 import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
 import xyz.nifeather.morph.utilities.DisguiseUtils;
 
@@ -13,7 +14,7 @@ import java.util.Map;
 
 public class FoxProperties extends BaseLivingEntityProperties<Fox>
 {
-    public final SingleProperty<Fox.Type> VARIANT = getSingle("fox/variant", Fox.Type.RED)
+    public final SingleProperty<Fox.Type> VARIANT = getSingle(PropertyNames.FOX_VARIANT, Fox.Type.RED)
             .withRandom(Fox.Type.values())
             .withValidInput("red", "snow");
 
@@ -25,7 +26,7 @@ public class FoxProperties extends BaseLivingEntityProperties<Fox>
     @Override
     protected @Nullable Pair<SingleProperty<?>, Object> parseSingleInput(String key, String value)
     {
-        if (key.equals(VARIANT.id()))
+        if (key.equals(PropertyNames.FOX_VARIANT))
         {
             var type = value.equals("red") ? Fox.Type.RED : Fox.Type.SNOW;
 

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/FoxProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/FoxProperties.java
@@ -15,7 +15,7 @@ public class FoxProperties extends BaseLivingEntityProperties<Fox>
 {
     public final SingleProperty<Fox.Type> VARIANT = getSingle("fox/variant", Fox.Type.RED)
             .withRandom(Fox.Type.values())
-            .withValidInput("default", "snow");
+            .withValidInput("red", "snow");
 
     public FoxProperties()
     {
@@ -27,7 +27,7 @@ public class FoxProperties extends BaseLivingEntityProperties<Fox>
     {
         if (key.equals(VARIANT.id()))
         {
-            var type = value.equals("default") ? Fox.Type.RED : Fox.Type.SNOW;
+            var type = value.equals("red") ? Fox.Type.RED : Fox.Type.SNOW;
 
             return Pair.of(VARIANT, type);
         }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/FoxProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/FoxProperties.java
@@ -13,7 +13,7 @@ import java.util.Map;
 
 public class FoxProperties extends BaseLivingEntityProperties<Fox>
 {
-    public final SingleProperty<Fox.Type> VARIANT = getSingle("fox_variant", Fox.Type.RED)
+    public final SingleProperty<Fox.Type> VARIANT = getSingle("fox/variant", Fox.Type.RED)
             .withRandom(Fox.Type.values())
             .withValidInput("default", "snow");
 
@@ -57,7 +57,7 @@ public class FoxProperties extends BaseLivingEntityProperties<Fox>
     public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
     {
         return Map.of(
-                "variant", propertyHandler.get(VARIANT).name().toLowerCase()
+                VARIANT.id(), propertyHandler.get(VARIANT).name().toLowerCase()
         );
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/FoxProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/FoxProperties.java
@@ -1,11 +1,17 @@
 package xyz.nifeather.morph.misc.disguiseProperty.values;
 
 import it.unimi.dsi.fastutil.Pair;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Fox;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import xyz.nifeather.morph.misc.disguiseProperty.PropertyHandler;
 import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
+import xyz.nifeather.morph.utilities.DisguiseUtils;
 
-public class FoxProperties extends AbstractProperties
+import java.util.Map;
+
+public class FoxProperties extends BaseLivingEntityProperties<Fox>
 {
     public final SingleProperty<Fox.Type> VARIANT = getSingle("fox_variant", Fox.Type.RED)
             .withRandom(Fox.Type.values())
@@ -26,6 +32,32 @@ public class FoxProperties extends AbstractProperties
             return Pair.of(VARIANT, type);
         }
 
-        return null;
+        return super.parseSingleInput(key, value);
+    }
+
+    @Override
+    protected @Nullable Fox tryCastEntity(@Nullable Entity targetEntity)
+    {
+        return targetEntity instanceof Fox fox ? fox : null;
+    }
+
+    @Override
+    protected void setupPropertiesFromEntity(PropertyHandler propertyHandler, @NotNull Fox fox)
+    {
+        propertyHandler.set(VARIANT, fox.getFoxType());
+    }
+
+    @Override
+    protected void setupDefaultProperties(PropertyHandler propertyHandler)
+    {
+        propertyHandler.set(VARIANT, DisguiseUtils.pick(VARIANT.getRandomValues()));
+    }
+
+    @Override
+    public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
+    {
+        return Map.of(
+                "variant", propertyHandler.get(VARIANT).name().toLowerCase()
+        );
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/FoxProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/FoxProperties.java
@@ -54,10 +54,9 @@ public class FoxProperties extends BaseLivingEntityProperties<Fox>
     }
 
     @Override
-    public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
+    protected void appendNetworkMap(PropertyHandler propertyHandler, Map<String, String> map)
     {
-        return Map.of(
-                VARIANT.id(), propertyHandler.get(VARIANT).name().toLowerCase()
-        );
+        super.appendNetworkMap(propertyHandler, map);
+        map.put(VARIANT.id(), propertyHandler.get(VARIANT).name().toLowerCase());
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/FrogProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/FrogProperties.java
@@ -70,10 +70,9 @@ public class FrogProperties extends BaseLivingEntityProperties<Frog>
     }
 
     @Override
-    public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
+    protected void appendNetworkMap(PropertyHandler propertyHandler, Map<String, String> map)
     {
-        return Map.of(
-                VARIANT.id(), propertyHandler.get(VARIANT).key().asString()
-        );
+        super.appendNetworkMap(propertyHandler, map);
+        map.put(VARIANT.id(), propertyHandler.get(VARIANT).key().asString());
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/FrogProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/FrogProperties.java
@@ -3,14 +3,18 @@ package xyz.nifeather.morph.misc.disguiseProperty.values;
 import io.papermc.paper.registry.RegistryAccess;
 import io.papermc.paper.registry.RegistryKey;
 import it.unimi.dsi.fastutil.Pair;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Frog;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import xyz.nifeather.morph.misc.disguiseProperty.PropertyHandler;
 import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
+import xyz.nifeather.morph.utilities.DisguiseUtils;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-public class FrogProperties extends AbstractProperties
+public class FrogProperties extends BaseLivingEntityProperties<Frog>
 {
     private final Map<String, Frog.Variant> variantMap = new ConcurrentHashMap<>();
 
@@ -43,6 +47,33 @@ public class FrogProperties extends AbstractProperties
             if (match != null)
                 return Pair.of(VARIANT, match);
         }
-        return null;
+
+        return super.parseSingleInput(key, value);
+    }
+
+    @Override
+    protected @Nullable Frog tryCastEntity(@Nullable Entity targetEntity)
+    {
+        return targetEntity instanceof Frog frog ? frog : null;
+    }
+
+    @Override
+    protected void setupPropertiesFromEntity(PropertyHandler propertyHandler, @NotNull Frog frog)
+    {
+        propertyHandler.set(VARIANT, frog.getVariant());
+    }
+
+    @Override
+    protected void setupDefaultProperties(PropertyHandler propertyHandler)
+    {
+        propertyHandler.set(VARIANT, DisguiseUtils.pick(VARIANT.getRandomValues()));
+    }
+
+    @Override
+    public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
+    {
+        return Map.of(
+                "variant", propertyHandler.get(VARIANT).key().asString()
+        );
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/FrogProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/FrogProperties.java
@@ -8,6 +8,7 @@ import org.bukkit.entity.Frog;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import xyz.nifeather.morph.misc.disguiseProperty.PropertyHandler;
+import xyz.nifeather.morph.misc.disguiseProperty.PropertyNames;
 import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
 import xyz.nifeather.morph.utilities.DisguiseUtils;
 
@@ -24,7 +25,7 @@ public class FrogProperties extends BaseLivingEntityProperties<Frog>
             variantMap.put(variant.key().asString(), variant);
     }
 
-    public final SingleProperty<Frog.Variant> VARIANT = getSingle("frog/variant", Frog.Variant.TEMPERATE)
+    public final SingleProperty<Frog.Variant> VARIANT = getSingle(PropertyNames.FROG_VARIANT, Frog.Variant.TEMPERATE)
             .withRandom(Frog.Variant.TEMPERATE, Frog.Variant.COLD, Frog.Variant.WARM);
 
     public FrogProperties()
@@ -40,7 +41,7 @@ public class FrogProperties extends BaseLivingEntityProperties<Frog>
     @Override
     protected @Nullable Pair<SingleProperty<?>, Object> parseSingleInput(String key, String value)
     {
-        if (key.equals(VARIANT.id()))
+        if (key.equals(PropertyNames.FROG_VARIANT))
         {
             var match = variantMap.getOrDefault(value, null);
 

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/FrogProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/FrogProperties.java
@@ -24,7 +24,7 @@ public class FrogProperties extends BaseLivingEntityProperties<Frog>
             variantMap.put(variant.key().asString(), variant);
     }
 
-    public final SingleProperty<Frog.Variant> VARIANT = getSingle("frog_variant", Frog.Variant.TEMPERATE)
+    public final SingleProperty<Frog.Variant> VARIANT = getSingle("frog/variant", Frog.Variant.TEMPERATE)
             .withRandom(Frog.Variant.TEMPERATE, Frog.Variant.COLD, Frog.Variant.WARM);
 
     public FrogProperties()
@@ -73,7 +73,7 @@ public class FrogProperties extends BaseLivingEntityProperties<Frog>
     public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
     {
         return Map.of(
-                "variant", propertyHandler.get(VARIANT).key().asString()
+                VARIANT.id(), propertyHandler.get(VARIANT).key().asString()
         );
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/GoatProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/GoatProperties.java
@@ -13,11 +13,11 @@ import java.util.Map;
 
 public class GoatProperties extends BaseLivingEntityProperties<Goat>
 {
-    public final SingleProperty<Boolean> HAS_LEFT_HORN = getSingle("goat_has_left_horn", true)
+    public final SingleProperty<Boolean> HAS_LEFT_HORN = getSingle("goat/has_left_horn", true)
             .withRandom(true, true, true, false)
             .withValidInput("false", "true");
 
-    public final SingleProperty<Boolean> HAS_RIGHT_HORN = getSingle("goat_has_right_horn", true)
+    public final SingleProperty<Boolean> HAS_RIGHT_HORN = getSingle("goat/has_right_horn", true)
             .withRandom(true, true, true, false)
             .withValidInput("false", "true");
 
@@ -31,8 +31,8 @@ public class GoatProperties extends BaseLivingEntityProperties<Goat>
     {
         return switch (key)
         {
-            case "goat_has_left_horn" -> Pair.of(HAS_LEFT_HORN, Boolean.valueOf(value));
-            case "goat_has_right_horn" -> Pair.of(HAS_RIGHT_HORN, Boolean.valueOf(value));
+            case "goat/has_left_horn" -> Pair.of(HAS_LEFT_HORN, Boolean.valueOf(value));
+            case "goat/has_right_horn" -> Pair.of(HAS_RIGHT_HORN, Boolean.valueOf(value));
 
             default -> super.parseSingleInput(key, value);
         };
@@ -62,8 +62,8 @@ public class GoatProperties extends BaseLivingEntityProperties<Goat>
     public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
     {
         return Map.of(
-                "has_left_horn", propertyHandler.get(HAS_LEFT_HORN).toString().toLowerCase(),
-                "has_right_horn", propertyHandler.get(HAS_RIGHT_HORN).toString().toLowerCase()
+                HAS_LEFT_HORN.id(), propertyHandler.get(HAS_LEFT_HORN).toString().toLowerCase(),
+                HAS_RIGHT_HORN.id(), propertyHandler.get(HAS_RIGHT_HORN).toString().toLowerCase()
         );
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/GoatProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/GoatProperties.java
@@ -59,11 +59,10 @@ public class GoatProperties extends BaseLivingEntityProperties<Goat>
     }
 
     @Override
-    public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
+    protected void appendNetworkMap(PropertyHandler propertyHandler, Map<String, String> map)
     {
-        return Map.of(
-                HAS_LEFT_HORN.id(), propertyHandler.get(HAS_LEFT_HORN).toString().toLowerCase(),
-                HAS_RIGHT_HORN.id(), propertyHandler.get(HAS_RIGHT_HORN).toString().toLowerCase()
-        );
+        super.appendNetworkMap(propertyHandler, map);
+        map.put(HAS_LEFT_HORN.id(), propertyHandler.get(HAS_LEFT_HORN).toString().toLowerCase());
+        map.put(HAS_RIGHT_HORN.id(), propertyHandler.get(HAS_RIGHT_HORN).toString().toLowerCase());
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/GoatProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/GoatProperties.java
@@ -6,6 +6,7 @@ import org.bukkit.entity.Goat;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import xyz.nifeather.morph.misc.disguiseProperty.PropertyHandler;
+import xyz.nifeather.morph.misc.disguiseProperty.PropertyNames;
 import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
 import xyz.nifeather.morph.utilities.DisguiseUtils;
 
@@ -13,11 +14,11 @@ import java.util.Map;
 
 public class GoatProperties extends BaseLivingEntityProperties<Goat>
 {
-    public final SingleProperty<Boolean> HAS_LEFT_HORN = getSingle("goat/has_left_horn", true)
+    public final SingleProperty<Boolean> HAS_LEFT_HORN = getSingle(PropertyNames.GOAT_HAS_LEFT_HORN, true)
             .withRandom(true, true, true, false)
             .withValidInput("false", "true");
 
-    public final SingleProperty<Boolean> HAS_RIGHT_HORN = getSingle("goat/has_right_horn", true)
+    public final SingleProperty<Boolean> HAS_RIGHT_HORN = getSingle(PropertyNames.GOAT_HAS_RIGHT_HORN, true)
             .withRandom(true, true, true, false)
             .withValidInput("false", "true");
 
@@ -31,8 +32,8 @@ public class GoatProperties extends BaseLivingEntityProperties<Goat>
     {
         return switch (key)
         {
-            case "goat/has_left_horn" -> Pair.of(HAS_LEFT_HORN, Boolean.valueOf(value));
-            case "goat/has_right_horn" -> Pair.of(HAS_RIGHT_HORN, Boolean.valueOf(value));
+            case PropertyNames.GOAT_HAS_LEFT_HORN -> Pair.of(HAS_LEFT_HORN, Boolean.valueOf(value));
+            case PropertyNames.GOAT_HAS_RIGHT_HORN -> Pair.of(HAS_RIGHT_HORN, Boolean.valueOf(value));
 
             default -> super.parseSingleInput(key, value);
         };

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/GoatProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/GoatProperties.java
@@ -1,10 +1,17 @@
 package xyz.nifeather.morph.misc.disguiseProperty.values;
 
 import it.unimi.dsi.fastutil.Pair;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Goat;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import xyz.nifeather.morph.misc.disguiseProperty.PropertyHandler;
 import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
+import xyz.nifeather.morph.utilities.DisguiseUtils;
 
-public class GoatProperties extends AbstractProperties
+import java.util.Map;
+
+public class GoatProperties extends BaseLivingEntityProperties<Goat>
 {
     public final SingleProperty<Boolean> HAS_LEFT_HORN = getSingle("goat_has_left_horn", true)
             .withRandom(true, true, true, false)
@@ -27,7 +34,36 @@ public class GoatProperties extends AbstractProperties
             case "goat_has_left_horn" -> Pair.of(HAS_LEFT_HORN, Boolean.valueOf(value));
             case "goat_has_right_horn" -> Pair.of(HAS_RIGHT_HORN, Boolean.valueOf(value));
 
-            default -> null;
+            default -> super.parseSingleInput(key, value);
         };
+    }
+
+    @Override
+    protected @Nullable Goat tryCastEntity(@Nullable Entity targetEntity)
+    {
+        return targetEntity instanceof Goat goat ? goat : null;
+    }
+
+    @Override
+    protected void setupPropertiesFromEntity(PropertyHandler propertyHandler, @NotNull Goat goat)
+    {
+        propertyHandler.set(HAS_LEFT_HORN, goat.hasLeftHorn());
+        propertyHandler.set(HAS_RIGHT_HORN, goat.hasRightHorn());
+    }
+
+    @Override
+    protected void setupDefaultProperties(PropertyHandler propertyHandler)
+    {
+        propertyHandler.set(HAS_RIGHT_HORN, DisguiseUtils.pick(HAS_RIGHT_HORN.getRandomValues()));
+        propertyHandler.set(HAS_LEFT_HORN, DisguiseUtils.pick(HAS_LEFT_HORN.getRandomValues()));
+    }
+
+    @Override
+    public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
+    {
+        return Map.of(
+                "has_left_horn", propertyHandler.get(HAS_LEFT_HORN).toString().toLowerCase(),
+                "has_right_horn", propertyHandler.get(HAS_RIGHT_HORN).toString().toLowerCase()
+        );
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/HappyGhastProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/HappyGhastProperties.java
@@ -12,7 +12,7 @@ import java.util.Map;
 
 public class HappyGhastProperties extends BaseLivingEntityProperties<HappyGhast>
 {
-    public final SingleProperty<Boolean> IS_GHASTLING = getSingle("happy_ghast_is_ghastling", false)
+    public final SingleProperty<Boolean> IS_GHASTLING = getSingle("happy_ghast/ghastling", false)
             .withValidInput("true", "false");
 
     public HappyGhastProperties()
@@ -51,7 +51,7 @@ public class HappyGhastProperties extends BaseLivingEntityProperties<HappyGhast>
     public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
     {
         return Map.of(
-                "is_ghastling", propertyHandler.get(IS_GHASTLING).toString().toLowerCase()
+                IS_GHASTLING.id(), propertyHandler.get(IS_GHASTLING).toString().toLowerCase()
         );
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/HappyGhastProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/HappyGhastProperties.java
@@ -48,10 +48,9 @@ public class HappyGhastProperties extends BaseLivingEntityProperties<HappyGhast>
     }
 
     @Override
-    public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
+    protected void appendNetworkMap(PropertyHandler propertyHandler, Map<String, String> map)
     {
-        return Map.of(
-                IS_GHASTLING.id(), propertyHandler.get(IS_GHASTLING).toString().toLowerCase()
-        );
+        super.appendNetworkMap(propertyHandler, map);
+        map.put(IS_GHASTLING.id(), propertyHandler.get(IS_GHASTLING).toString().toLowerCase());
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/HappyGhastProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/HappyGhastProperties.java
@@ -6,13 +6,14 @@ import org.bukkit.entity.HappyGhast;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import xyz.nifeather.morph.misc.disguiseProperty.PropertyHandler;
+import xyz.nifeather.morph.misc.disguiseProperty.PropertyNames;
 import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
 
 import java.util.Map;
 
 public class HappyGhastProperties extends BaseLivingEntityProperties<HappyGhast>
 {
-    public final SingleProperty<Boolean> IS_GHASTLING = getSingle("happy_ghast/ghastling", false)
+    public final SingleProperty<Boolean> IS_GHASTLING = getSingle(PropertyNames.HAPPY_GHAST_IS_GHASTLING, false)
             .withValidInput("true", "false");
 
     public HappyGhastProperties()
@@ -23,7 +24,7 @@ public class HappyGhastProperties extends BaseLivingEntityProperties<HappyGhast>
     @Override
     protected @Nullable Pair<SingleProperty<?>, Object> parseSingleInput(String key, String value)
     {
-        if (key.equals(IS_GHASTLING.id()))
+        if (key.equals(PropertyNames.HAPPY_GHAST_IS_GHASTLING))
             return Pair.of(IS_GHASTLING, Boolean.parseBoolean(value));
 
         return super.parseSingleInput(key, value);

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/HappyGhastProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/HappyGhastProperties.java
@@ -1,10 +1,16 @@
 package xyz.nifeather.morph.misc.disguiseProperty.values;
 
 import it.unimi.dsi.fastutil.Pair;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.HappyGhast;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import xyz.nifeather.morph.misc.disguiseProperty.PropertyHandler;
 import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
 
-public class HappyGhastProperties extends AbstractProperties
+import java.util.Map;
+
+public class HappyGhastProperties extends BaseLivingEntityProperties<HappyGhast>
 {
     public final SingleProperty<Boolean> IS_GHASTLING = getSingle("happy_ghast_is_ghastling", false)
             .withValidInput("true", "false");
@@ -20,6 +26,32 @@ public class HappyGhastProperties extends AbstractProperties
         if (key.equals(IS_GHASTLING.id()))
             return Pair.of(IS_GHASTLING, Boolean.parseBoolean(value));
 
-        return null;
+        return super.parseSingleInput(key, value);
+    }
+
+    @Override
+    protected @Nullable HappyGhast tryCastEntity(@Nullable Entity targetEntity)
+    {
+        return targetEntity instanceof HappyGhast happyGhast ? happyGhast : null;
+    }
+
+    @Override
+    protected void setupPropertiesFromEntity(PropertyHandler propertyHandler, @NotNull HappyGhast happyGhast)
+    {
+        propertyHandler.set(IS_GHASTLING, !happyGhast.isAdult());
+    }
+
+    @Override
+    protected void setupDefaultProperties(PropertyHandler propertyHandler)
+    {
+        propertyHandler.set(IS_GHASTLING, false);
+    }
+
+    @Override
+    public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
+    {
+        return Map.of(
+                "is_ghastling", propertyHandler.get(IS_GHASTLING).toString().toLowerCase()
+        );
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/HoglinProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/HoglinProperties.java
@@ -47,10 +47,9 @@ public class HoglinProperties extends BaseLivingEntityProperties<Hoglin>
     }
 
     @Override
-    public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
+    protected void appendNetworkMap(PropertyHandler propertyHandler, Map<String, String> map)
     {
-        return Map.of(
-                IS_BABY.id(), propertyHandler.get(IS_BABY).toString().toLowerCase()
-        );
+        super.appendNetworkMap(propertyHandler, map);
+        map.put(IS_BABY.id(), propertyHandler.get(IS_BABY).toString().toLowerCase());
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/HoglinProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/HoglinProperties.java
@@ -1,0 +1,55 @@
+package xyz.nifeather.morph.misc.disguiseProperty.values;
+
+import it.unimi.dsi.fastutil.Pair;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Hoglin;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import xyz.nifeather.morph.misc.disguiseProperty.PropertyHandler;
+import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
+
+import java.util.Map;
+
+public class HoglinProperties extends BaseLivingEntityProperties<Hoglin>
+{
+    public final SingleProperty<Boolean> IS_BABY = getSingle("is_baby", false);
+
+    public HoglinProperties()
+    {
+        registerSingle(IS_BABY);
+    }
+
+    @Override
+    protected @Nullable Hoglin tryCastEntity(@Nullable Entity targetEntity)
+    {
+        return targetEntity instanceof Hoglin hoglin ? hoglin : null;
+    }
+
+    @Override
+    protected @Nullable Pair<SingleProperty<?>, Object> parseSingleInput(String key, String value)
+    {
+        if (key.equals(IS_BABY.id()))
+            return Pair.of(IS_BABY, Boolean.valueOf(value));
+
+        return super.parseSingleInput(key, value);
+    }
+
+    @Override
+    protected void setupPropertiesFromEntity(PropertyHandler propertyHandler, @NotNull Hoglin targetEntity)
+    {
+        propertyHandler.set(IS_BABY, !targetEntity.isAdult());
+    }
+
+    @Override
+    protected void setupDefaultProperties(PropertyHandler propertyHandler)
+    {
+    }
+
+    @Override
+    public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
+    {
+        return Map.of(
+                "is_baby", propertyHandler.get(IS_BABY).toString().toLowerCase()
+        );
+    }
+}

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/HoglinProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/HoglinProperties.java
@@ -6,13 +6,14 @@ import org.bukkit.entity.Hoglin;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import xyz.nifeather.morph.misc.disguiseProperty.PropertyHandler;
+import xyz.nifeather.morph.misc.disguiseProperty.PropertyNames;
 import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
 
 import java.util.Map;
 
 public class HoglinProperties extends BaseLivingEntityProperties<Hoglin>
 {
-    public final SingleProperty<Boolean> IS_BABY = getSingle("hoglin/is_baby", false)
+    public final SingleProperty<Boolean> IS_BABY = getSingle(PropertyNames.HOGLIN_IS_BABY, false)
             .withValidInput("true", "false");
 
     public HoglinProperties()
@@ -29,7 +30,7 @@ public class HoglinProperties extends BaseLivingEntityProperties<Hoglin>
     @Override
     protected @Nullable Pair<SingleProperty<?>, Object> parseSingleInput(String key, String value)
     {
-        if (key.equals(IS_BABY.id()))
+        if (key.equals(PropertyNames.HOGLIN_IS_BABY))
             return Pair.of(IS_BABY, Boolean.valueOf(value));
 
         return super.parseSingleInput(key, value);

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/HoglinProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/HoglinProperties.java
@@ -12,7 +12,8 @@ import java.util.Map;
 
 public class HoglinProperties extends BaseLivingEntityProperties<Hoglin>
 {
-    public final SingleProperty<Boolean> IS_BABY = getSingle("is_baby", false);
+    public final SingleProperty<Boolean> IS_BABY = getSingle("hoglin/is_baby", false)
+            .withValidInput("true", "false");
 
     public HoglinProperties()
     {
@@ -49,7 +50,7 @@ public class HoglinProperties extends BaseLivingEntityProperties<Hoglin>
     public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
     {
         return Map.of(
-                "is_baby", propertyHandler.get(IS_BABY).toString().toLowerCase()
+                IS_BABY.id(), propertyHandler.get(IS_BABY).toString().toLowerCase()
         );
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/HorseProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/HorseProperties.java
@@ -1,14 +1,18 @@
 package xyz.nifeather.morph.misc.disguiseProperty.values;
 
 import it.unimi.dsi.fastutil.Pair;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Horse;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import xyz.nifeather.morph.misc.disguiseProperty.PropertyHandler;
 import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
+import xyz.nifeather.morph.utilities.DisguiseUtils;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-public class HorseProperties extends AbstractProperties
+public class HorseProperties extends BaseLivingEntityProperties<Horse>
 {
     private final Map<String, Horse.Color> colorMap = new ConcurrentHashMap<>();
     private final Map<String, Horse.Style> styleMap = new ConcurrentHashMap<>();
@@ -60,6 +64,35 @@ public class HorseProperties extends AbstractProperties
             }
         }
 
-        return null;
+        return super.parseSingleInput(key, value);
+    }
+
+    @Override
+    protected @Nullable Horse tryCastEntity(@Nullable Entity targetEntity)
+    {
+        return targetEntity instanceof Horse horse ? horse : null;
+    }
+
+    @Override
+    protected void setupPropertiesFromEntity(PropertyHandler propertyHandler, @NotNull Horse horse)
+    {
+        propertyHandler.set(COLOR, horse.getColor());
+        propertyHandler.set(STYLE, horse.getStyle());
+    }
+
+    @Override
+    protected void setupDefaultProperties(PropertyHandler propertyHandler)
+    {
+        propertyHandler.set(COLOR, DisguiseUtils.pick(COLOR.getRandomValues()));
+        propertyHandler.set(STYLE, DisguiseUtils.pick(STYLE.getRandomValues()));
+    }
+
+    @Override
+    public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
+    {
+        return Map.of(
+                "color", propertyHandler.get(COLOR).name().toLowerCase(),
+                "style", propertyHandler.get(STYLE).name().toLowerCase()
+        );
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/HorseProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/HorseProperties.java
@@ -88,11 +88,10 @@ public class HorseProperties extends BaseLivingEntityProperties<Horse>
     }
 
     @Override
-    public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
+    protected void appendNetworkMap(PropertyHandler propertyHandler, Map<String, String> map)
     {
-        return Map.of(
-                COLOR.id(), propertyHandler.get(COLOR).name().toLowerCase(),
-                STYLE.id(), propertyHandler.get(STYLE).name().toLowerCase()
-        );
+        super.appendNetworkMap(propertyHandler, map);
+        map.put(COLOR.id(), propertyHandler.get(COLOR).name().toLowerCase());
+        map.put(STYLE.id(), propertyHandler.get(STYLE).name().toLowerCase());
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/HorseProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/HorseProperties.java
@@ -26,10 +26,10 @@ public class HorseProperties extends BaseLivingEntityProperties<Horse>
             styleMap.put(style.name().toLowerCase(), style);
     }
 
-    public final SingleProperty<Horse.Color> COLOR = getSingle("horse_color", Horse.Color.WHITE)
+    public final SingleProperty<Horse.Color> COLOR = getSingle("horse/color", Horse.Color.WHITE)
             .withRandom(Horse.Color.values());
 
-    public final SingleProperty<Horse.Style> STYLE = getSingle("horse_style", Horse.Style.NONE)
+    public final SingleProperty<Horse.Style> STYLE = getSingle("horse/style", Horse.Style.NONE)
             .withRandom(Horse.Style.values());
 
     public HorseProperties()
@@ -47,7 +47,7 @@ public class HorseProperties extends BaseLivingEntityProperties<Horse>
     {
         switch (key)
         {
-            case "horse_color" ->
+            case "horse/color" ->
             {
                 var color = colorMap.getOrDefault(value, null);
 
@@ -55,7 +55,7 @@ public class HorseProperties extends BaseLivingEntityProperties<Horse>
                     return Pair.of(COLOR, color);
             }
 
-            case "horse_style" ->
+            case "horse/style" ->
             {
                 var style = styleMap.getOrDefault(value, null);
 
@@ -91,8 +91,8 @@ public class HorseProperties extends BaseLivingEntityProperties<Horse>
     public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
     {
         return Map.of(
-                "color", propertyHandler.get(COLOR).name().toLowerCase(),
-                "style", propertyHandler.get(STYLE).name().toLowerCase()
+                COLOR.id(), propertyHandler.get(COLOR).name().toLowerCase(),
+                STYLE.id(), propertyHandler.get(STYLE).name().toLowerCase()
         );
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/HorseProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/HorseProperties.java
@@ -6,6 +6,7 @@ import org.bukkit.entity.Horse;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import xyz.nifeather.morph.misc.disguiseProperty.PropertyHandler;
+import xyz.nifeather.morph.misc.disguiseProperty.PropertyNames;
 import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
 import xyz.nifeather.morph.utilities.DisguiseUtils;
 
@@ -26,10 +27,10 @@ public class HorseProperties extends BaseLivingEntityProperties<Horse>
             styleMap.put(style.name().toLowerCase(), style);
     }
 
-    public final SingleProperty<Horse.Color> COLOR = getSingle("horse/color", Horse.Color.WHITE)
+    public final SingleProperty<Horse.Color> COLOR = getSingle(PropertyNames.HORSE_COLOR, Horse.Color.WHITE)
             .withRandom(Horse.Color.values());
 
-    public final SingleProperty<Horse.Style> STYLE = getSingle("horse/style", Horse.Style.NONE)
+    public final SingleProperty<Horse.Style> STYLE = getSingle(PropertyNames.HORSE_STYLE, Horse.Style.NONE)
             .withRandom(Horse.Style.values());
 
     public HorseProperties()
@@ -47,7 +48,7 @@ public class HorseProperties extends BaseLivingEntityProperties<Horse>
     {
         switch (key)
         {
-            case "horse/color" ->
+            case PropertyNames.HORSE_COLOR ->
             {
                 var color = colorMap.getOrDefault(value, null);
 
@@ -55,7 +56,7 @@ public class HorseProperties extends BaseLivingEntityProperties<Horse>
                     return Pair.of(COLOR, color);
             }
 
-            case "horse/style" ->
+            case PropertyNames.HORSE_STYLE ->
             {
                 var style = styleMap.getOrDefault(value, null);
 

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/LlamaProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/LlamaProperties.java
@@ -24,7 +24,7 @@ public class LlamaProperties extends BaseLivingEntityProperties<Llama>
             colorMap.put(value.name().toLowerCase(), value);
     }
 
-    public final SingleProperty<Llama.Color> COLOR = getSingle("llama_color", Color.CREAMY)
+    public final SingleProperty<Llama.Color> COLOR = getSingle("llama/color", Color.CREAMY)
             .withRandom(Color.values());
 
     public LlamaProperties()
@@ -71,7 +71,7 @@ public class LlamaProperties extends BaseLivingEntityProperties<Llama>
     public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
     {
         return Map.of(
-                "color", propertyHandler.get(COLOR).name().toLowerCase()
+                COLOR.id(), propertyHandler.get(COLOR).name().toLowerCase()
         );
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/LlamaProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/LlamaProperties.java
@@ -8,6 +8,7 @@ import org.checkerframework.checker.units.qual.C;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import xyz.nifeather.morph.misc.disguiseProperty.PropertyHandler;
+import xyz.nifeather.morph.misc.disguiseProperty.PropertyNames;
 import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
 import xyz.nifeather.morph.utilities.DisguiseUtils;
 
@@ -24,7 +25,7 @@ public class LlamaProperties extends BaseLivingEntityProperties<Llama>
             colorMap.put(value.name().toLowerCase(), value);
     }
 
-    public final SingleProperty<Llama.Color> COLOR = getSingle("llama/color", Color.CREAMY)
+    public final SingleProperty<Llama.Color> COLOR = getSingle(PropertyNames.LLAMA_COLOR, Color.CREAMY)
             .withRandom(Color.values());
 
     public LlamaProperties()
@@ -38,7 +39,7 @@ public class LlamaProperties extends BaseLivingEntityProperties<Llama>
     @Override
     protected @Nullable Pair<SingleProperty<?>, Object> parseSingleInput(String key, String value)
     {
-        if (key.equals(COLOR.id()))
+        if (key.equals(PropertyNames.LLAMA_COLOR))
         {
             var color = colorMap.getOrDefault(value, null);
 

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/LlamaProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/LlamaProperties.java
@@ -68,10 +68,9 @@ public class LlamaProperties extends BaseLivingEntityProperties<Llama>
     }
 
     @Override
-    public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
+    protected void appendNetworkMap(PropertyHandler propertyHandler, Map<String, String> map)
     {
-        return Map.of(
-                COLOR.id(), propertyHandler.get(COLOR).name().toLowerCase()
-        );
+        super.appendNetworkMap(propertyHandler, map);
+        map.put(COLOR.id(), propertyHandler.get(COLOR).name().toLowerCase());
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/LlamaProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/LlamaProperties.java
@@ -1,15 +1,20 @@
 package xyz.nifeather.morph.misc.disguiseProperty.values;
 
 import it.unimi.dsi.fastutil.Pair;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Llama;
 import org.bukkit.entity.Llama.Color;
+import org.checkerframework.checker.units.qual.C;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import xyz.nifeather.morph.misc.disguiseProperty.PropertyHandler;
 import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
+import xyz.nifeather.morph.utilities.DisguiseUtils;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-public class LlamaProperties extends AbstractProperties
+public class LlamaProperties extends BaseLivingEntityProperties<Llama>
 {
     private final Map<String, Color> colorMap = new ConcurrentHashMap<>();
 
@@ -41,6 +46,32 @@ public class LlamaProperties extends AbstractProperties
                 return Pair.of(COLOR, color);
         }
 
-        return null;
+        return super.parseSingleInput(key, value);
+    }
+
+    @Override
+    protected @Nullable Llama tryCastEntity(@Nullable Entity targetEntity)
+    {
+        return targetEntity instanceof Llama llama ? llama : null;
+    }
+
+    @Override
+    protected void setupPropertiesFromEntity(PropertyHandler propertyHandler, @NotNull Llama llama)
+    {
+        propertyHandler.set(COLOR, llama.getColor());
+    }
+
+    @Override
+    protected void setupDefaultProperties(PropertyHandler propertyHandler)
+    {
+        propertyHandler.set(COLOR, DisguiseUtils.pick(COLOR.getRandomValues()));
+    }
+
+    @Override
+    public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
+    {
+        return Map.of(
+                "color", propertyHandler.get(COLOR).name().toLowerCase()
+        );
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/MooshroomProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/MooshroomProperties.java
@@ -13,7 +13,7 @@ import java.util.Map;
 
 public class MooshroomProperties extends BaseLivingEntityProperties<MushroomCow>
 {
-    public final SingleProperty<MushroomCow.Variant> VARIANT = getSingle("mooshroom_variant", MushroomCow.Variant.RED)
+    public final SingleProperty<MushroomCow.Variant> VARIANT = getSingle("mooshroom/variant", MushroomCow.Variant.RED)
             .withRandom(MushroomCow.Variant.RED, MushroomCow.Variant.RED, MushroomCow.Variant.RED, MushroomCow.Variant.BROWN)
             .withValidInput("red", "brown");
 
@@ -58,7 +58,7 @@ public class MooshroomProperties extends BaseLivingEntityProperties<MushroomCow>
     public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
     {
         return Map.of(
-                "variant", propertyHandler.get(VARIANT).name().toLowerCase()
+                VARIANT.id(), propertyHandler.get(VARIANT).name().toLowerCase()
         );
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/MooshroomProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/MooshroomProperties.java
@@ -6,6 +6,7 @@ import org.bukkit.entity.MushroomCow;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import xyz.nifeather.morph.misc.disguiseProperty.PropertyHandler;
+import xyz.nifeather.morph.misc.disguiseProperty.PropertyNames;
 import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
 import xyz.nifeather.morph.utilities.DisguiseUtils;
 
@@ -13,7 +14,7 @@ import java.util.Map;
 
 public class MooshroomProperties extends BaseLivingEntityProperties<MushroomCow>
 {
-    public final SingleProperty<MushroomCow.Variant> VARIANT = getSingle("mooshroom/variant", MushroomCow.Variant.RED)
+    public final SingleProperty<MushroomCow.Variant> VARIANT = getSingle(PropertyNames.MOOSHROOM_VARIANT, MushroomCow.Variant.RED)
             .withRandom(MushroomCow.Variant.RED, MushroomCow.Variant.RED, MushroomCow.Variant.RED, MushroomCow.Variant.BROWN)
             .withValidInput("red", "brown");
 
@@ -25,7 +26,7 @@ public class MooshroomProperties extends BaseLivingEntityProperties<MushroomCow>
     @Override
     protected @Nullable Pair<SingleProperty<?>, Object> parseSingleInput(String key, String value)
     {
-        if (key.equals(VARIANT.id()))
+        if (key.equals(PropertyNames.MOOSHROOM_VARIANT))
         {
             if (value.equals("red"))
                 return Pair.of(VARIANT, MushroomCow.Variant.RED);

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/MooshroomProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/MooshroomProperties.java
@@ -55,10 +55,9 @@ public class MooshroomProperties extends BaseLivingEntityProperties<MushroomCow>
     }
 
     @Override
-    public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
+    protected void appendNetworkMap(PropertyHandler propertyHandler, Map<String, String> map)
     {
-        return Map.of(
-                VARIANT.id(), propertyHandler.get(VARIANT).name().toLowerCase()
-        );
+        super.appendNetworkMap(propertyHandler, map);
+        map.put(VARIANT.id(), propertyHandler.get(VARIANT).name().toLowerCase());
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/MooshroomProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/MooshroomProperties.java
@@ -1,11 +1,17 @@
 package xyz.nifeather.morph.misc.disguiseProperty.values;
 
 import it.unimi.dsi.fastutil.Pair;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.MushroomCow;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import xyz.nifeather.morph.misc.disguiseProperty.PropertyHandler;
 import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
+import xyz.nifeather.morph.utilities.DisguiseUtils;
 
-public class MooshroomProperties extends AbstractProperties
+import java.util.Map;
+
+public class MooshroomProperties extends BaseLivingEntityProperties<MushroomCow>
 {
     public final SingleProperty<MushroomCow.Variant> VARIANT = getSingle("mooshroom_variant", MushroomCow.Variant.RED)
             .withRandom(MushroomCow.Variant.RED, MushroomCow.Variant.RED, MushroomCow.Variant.RED, MushroomCow.Variant.BROWN)
@@ -27,6 +33,32 @@ public class MooshroomProperties extends AbstractProperties
                 return Pair.of(VARIANT, MushroomCow.Variant.BROWN);
         }
 
-        return null;
+        return super.parseSingleInput(key, value);
+    }
+
+    @Override
+    protected @Nullable MushroomCow tryCastEntity(@Nullable Entity targetEntity)
+    {
+        return targetEntity instanceof MushroomCow mushroomCow ? mushroomCow : null;
+    }
+
+    @Override
+    protected void setupPropertiesFromEntity(PropertyHandler propertyHandler, @NotNull MushroomCow targetEntity)
+    {
+        propertyHandler.set(VARIANT, targetEntity.getVariant());
+    }
+
+    @Override
+    protected void setupDefaultProperties(PropertyHandler propertyHandler)
+    {
+        propertyHandler.set(VARIANT, DisguiseUtils.pick(VARIANT.getRandomValues()));
+    }
+
+    @Override
+    public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
+    {
+        return Map.of(
+                "variant", propertyHandler.get(VARIANT).name().toLowerCase()
+        );
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/OffTreeProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/OffTreeProperties.java
@@ -7,8 +7,8 @@ import java.util.UUID;
 
 public class OffTreeProperties
 {
-    public static final SingleProperty<Boolean> IS_BABY = SingleProperty.of("is_baby", false).withValidInput("true", "false");
-    public static final SingleProperty<UUID> VIRTUAL_ENTITY_UUID = SingleProperty.of("virtual_entity_uuid", UUID.randomUUID());
-    public static final SingleProperty<DisguiseEquipment> FAKE_EQUIPMENT = SingleProperty.of("fake_equip", new DisguiseEquipment());
-    public static final SingleProperty<Boolean> DISPLAY_FAKE_EQUIPMENT = SingleProperty.of("display_fake_equipment", false);
+    public static final SingleProperty<Boolean> IS_BABY = SingleProperty.of("offtree/is_baby", false).withValidInput("true", "false");
+    public static final SingleProperty<UUID> VIRTUAL_ENTITY_UUID = SingleProperty.of("offtree/virtual_entity_uuid", UUID.randomUUID());
+    public static final SingleProperty<DisguiseEquipment> FAKE_EQUIPMENT = SingleProperty.of("offtree/fake_equip", new DisguiseEquipment());
+    public static final SingleProperty<Boolean> DISPLAY_FAKE_EQUIPMENT = SingleProperty.of("offtree/display_fake_equipment", false);
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/PandaProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/PandaProperties.java
@@ -7,6 +7,7 @@ import org.bukkit.entity.Panda.Gene;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import xyz.nifeather.morph.misc.disguiseProperty.PropertyHandler;
+import xyz.nifeather.morph.misc.disguiseProperty.PropertyNames;
 import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
 import xyz.nifeather.morph.utilities.DisguiseUtils;
 
@@ -23,10 +24,10 @@ public class PandaProperties extends BaseLivingEntityProperties<Panda>
             geneMap.put(gene.name().toLowerCase(), gene);
     }
 
-    public final SingleProperty<Panda.Gene> MAIN_GENE = getSingle("panda/main_gene", Gene.NORMAL)
+    public final SingleProperty<Panda.Gene> MAIN_GENE = getSingle(PropertyNames.PANDA_MAIN_GENE, Gene.NORMAL)
             .withRandom(Gene.values());
 
-    public final SingleProperty<Panda.Gene> HIDDEN_GENE = getSingle("panda/hidden_gene", Gene.NORMAL)
+    public final SingleProperty<Panda.Gene> HIDDEN_GENE = getSingle(PropertyNames.PANDA_HIDDEN_GENE, Gene.NORMAL)
             .withRandom(Gene.values());
 
     public PandaProperties()
@@ -44,7 +45,7 @@ public class PandaProperties extends BaseLivingEntityProperties<Panda>
     {
         switch (key)
         {
-            case "panda/main_gene" ->
+            case PropertyNames.PANDA_MAIN_GENE ->
             {
                 var gene = geneMap.getOrDefault(value, null);
 
@@ -52,7 +53,7 @@ public class PandaProperties extends BaseLivingEntityProperties<Panda>
                     return Pair.of(MAIN_GENE, gene);
             }
 
-            case "panda/hidden_gene" ->
+            case PropertyNames.PANDA_HIDDEN_GENE ->
             {
                 var gene = geneMap.getOrDefault(value, null);
 

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/PandaProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/PandaProperties.java
@@ -23,10 +23,10 @@ public class PandaProperties extends BaseLivingEntityProperties<Panda>
             geneMap.put(gene.name().toLowerCase(), gene);
     }
 
-    public final SingleProperty<Panda.Gene> MAIN_GENE = getSingle("panda_main_gene", Gene.NORMAL)
+    public final SingleProperty<Panda.Gene> MAIN_GENE = getSingle("panda/main_gene", Gene.NORMAL)
             .withRandom(Gene.values());
 
-    public final SingleProperty<Panda.Gene> HIDDEN_GENE = getSingle("panda_hidden_gene", Gene.NORMAL)
+    public final SingleProperty<Panda.Gene> HIDDEN_GENE = getSingle("panda/hidden_gene", Gene.NORMAL)
             .withRandom(Gene.values());
 
     public PandaProperties()
@@ -44,7 +44,7 @@ public class PandaProperties extends BaseLivingEntityProperties<Panda>
     {
         switch (key)
         {
-            case "panda_main_gene" ->
+            case "panda/main_gene" ->
             {
                 var gene = geneMap.getOrDefault(value, null);
 
@@ -52,7 +52,7 @@ public class PandaProperties extends BaseLivingEntityProperties<Panda>
                     return Pair.of(MAIN_GENE, gene);
             }
 
-            case "panda_hidden_gene" ->
+            case "panda/hidden_gene" ->
             {
                 var gene = geneMap.getOrDefault(value, null);
 
@@ -88,8 +88,8 @@ public class PandaProperties extends BaseLivingEntityProperties<Panda>
     public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
     {
         return Map.of(
-                "main_gene", propertyHandler.get(MAIN_GENE).name().toLowerCase(),
-                "hidden_gene", propertyHandler.get(HIDDEN_GENE).name().toLowerCase()
+                MAIN_GENE.id(), propertyHandler.get(MAIN_GENE).name().toLowerCase(),
+                HIDDEN_GENE.id(), propertyHandler.get(HIDDEN_GENE).name().toLowerCase()
         );
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/PandaProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/PandaProperties.java
@@ -85,11 +85,10 @@ public class PandaProperties extends BaseLivingEntityProperties<Panda>
     }
 
     @Override
-    public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
+    protected void appendNetworkMap(PropertyHandler propertyHandler, Map<String, String> map)
     {
-        return Map.of(
-                MAIN_GENE.id(), propertyHandler.get(MAIN_GENE).name().toLowerCase(),
-                HIDDEN_GENE.id(), propertyHandler.get(HIDDEN_GENE).name().toLowerCase()
-        );
+        super.appendNetworkMap(propertyHandler, map);
+        map.put(MAIN_GENE.id(), propertyHandler.get(MAIN_GENE).name().toLowerCase());
+        map.put(HIDDEN_GENE.id(), propertyHandler.get(HIDDEN_GENE).name().toLowerCase());
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/PandaProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/PandaProperties.java
@@ -1,15 +1,19 @@
 package xyz.nifeather.morph.misc.disguiseProperty.values;
 
 import it.unimi.dsi.fastutil.Pair;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Panda;
 import org.bukkit.entity.Panda.Gene;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import xyz.nifeather.morph.misc.disguiseProperty.PropertyHandler;
 import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
+import xyz.nifeather.morph.utilities.DisguiseUtils;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-public class PandaProperties extends AbstractProperties
+public class PandaProperties extends BaseLivingEntityProperties<Panda>
 {
     private final Map<String, Panda.Gene> geneMap = new ConcurrentHashMap<>();
 
@@ -57,6 +61,35 @@ public class PandaProperties extends AbstractProperties
             }
         }
 
-        return null;
+        return super.parseSingleInput(key, value);
+    }
+
+    @Override
+    protected @Nullable Panda tryCastEntity(@Nullable Entity targetEntity)
+    {
+        return targetEntity instanceof Panda panda ? panda : null;
+    }
+
+    @Override
+    protected void setupPropertiesFromEntity(PropertyHandler propertyHandler, @NotNull Panda targetEntity)
+    {
+        propertyHandler.set(MAIN_GENE, targetEntity.getMainGene());
+        propertyHandler.set(HIDDEN_GENE, targetEntity.getHiddenGene());
+    }
+
+    @Override
+    protected void setupDefaultProperties(PropertyHandler propertyHandler)
+    {
+        propertyHandler.set(MAIN_GENE, DisguiseUtils.pick(MAIN_GENE.getRandomValues()));
+        propertyHandler.set(HIDDEN_GENE, DisguiseUtils.pick(HIDDEN_GENE.getRandomValues()));
+    }
+
+    @Override
+    public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
+    {
+        return Map.of(
+                "main_gene", propertyHandler.get(MAIN_GENE).name().toLowerCase(),
+                "hidden_gene", propertyHandler.get(HIDDEN_GENE).name().toLowerCase()
+        );
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/ParrotProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/ParrotProperties.java
@@ -23,7 +23,7 @@ public class ParrotProperties extends BaseLivingEntityProperties<Parrot>
             variantMap.put(variant.name().toLowerCase(), variant);
     }
 
-    public final SingleProperty<Parrot.Variant> VARIANT = getSingle("parrot_variant", Variant.RED)
+    public final SingleProperty<Parrot.Variant> VARIANT = getSingle("parrot/variant", Variant.RED)
             .withRandom(Variant.values());
 
     public ParrotProperties()
@@ -70,7 +70,7 @@ public class ParrotProperties extends BaseLivingEntityProperties<Parrot>
     public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
     {
         return Map.of(
-                "variant", propertyHandler.get(VARIANT).name().toLowerCase()
+                VARIANT.id(), propertyHandler.get(VARIANT).name().toLowerCase()
         );
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/ParrotProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/ParrotProperties.java
@@ -7,6 +7,7 @@ import org.bukkit.entity.Parrot.Variant;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import xyz.nifeather.morph.misc.disguiseProperty.PropertyHandler;
+import xyz.nifeather.morph.misc.disguiseProperty.PropertyNames;
 import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
 import xyz.nifeather.morph.utilities.DisguiseUtils;
 
@@ -23,7 +24,7 @@ public class ParrotProperties extends BaseLivingEntityProperties<Parrot>
             variantMap.put(variant.name().toLowerCase(), variant);
     }
 
-    public final SingleProperty<Parrot.Variant> VARIANT = getSingle("parrot/variant", Variant.RED)
+    public final SingleProperty<Parrot.Variant> VARIANT = getSingle(PropertyNames.PARROT_VARIANT, Variant.RED)
             .withRandom(Variant.values());
 
     public ParrotProperties()
@@ -37,7 +38,7 @@ public class ParrotProperties extends BaseLivingEntityProperties<Parrot>
     @Override
     protected @Nullable Pair<SingleProperty<?>, Object> parseSingleInput(String key, String value)
     {
-        if (key.equals(VARIANT.id()))
+        if (key.equals(PropertyNames.PARROT_VARIANT))
         {
             var variant = variantMap.getOrDefault(value, null);
 

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/ParrotProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/ParrotProperties.java
@@ -1,15 +1,19 @@
 package xyz.nifeather.morph.misc.disguiseProperty.values;
 
 import it.unimi.dsi.fastutil.Pair;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Parrot;
 import org.bukkit.entity.Parrot.Variant;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import xyz.nifeather.morph.misc.disguiseProperty.PropertyHandler;
 import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
+import xyz.nifeather.morph.utilities.DisguiseUtils;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-public class ParrotProperties extends AbstractProperties
+public class ParrotProperties extends BaseLivingEntityProperties<Parrot>
 {
     private final Map<String, Variant> variantMap = new ConcurrentHashMap<>();
 
@@ -41,6 +45,32 @@ public class ParrotProperties extends AbstractProperties
                 return Pair.of(VARIANT, variant);
         }
 
-        return null;
+        return super.parseSingleInput(key, value);
+    }
+
+    @Override
+    protected @Nullable Parrot tryCastEntity(@Nullable Entity targetEntity)
+    {
+        return targetEntity instanceof Parrot parrot ? parrot : null;
+    }
+
+    @Override
+    protected void setupPropertiesFromEntity(PropertyHandler propertyHandler, @NotNull Parrot targetEntity)
+    {
+        propertyHandler.set(VARIANT, targetEntity.getVariant());
+    }
+
+    @Override
+    protected void setupDefaultProperties(PropertyHandler propertyHandler)
+    {
+        propertyHandler.set(VARIANT, DisguiseUtils.pick(VARIANT.getRandomValues()));
+    }
+
+    @Override
+    public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
+    {
+        return Map.of(
+                "variant", propertyHandler.get(VARIANT).name().toLowerCase()
+        );
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/ParrotProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/ParrotProperties.java
@@ -67,10 +67,9 @@ public class ParrotProperties extends BaseLivingEntityProperties<Parrot>
     }
 
     @Override
-    public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
+    protected void appendNetworkMap(PropertyHandler propertyHandler, Map<String, String> map)
     {
-        return Map.of(
-                VARIANT.id(), propertyHandler.get(VARIANT).name().toLowerCase()
-        );
+        super.appendNetworkMap(propertyHandler, map);
+        map.put(VARIANT.id(), propertyHandler.get(VARIANT).name().toLowerCase());
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/PhantomProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/PhantomProperties.java
@@ -6,6 +6,7 @@ import org.bukkit.entity.Phantom;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import xyz.nifeather.morph.misc.disguiseProperty.PropertyHandler;
+import xyz.nifeather.morph.misc.disguiseProperty.PropertyNames;
 import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
 import xyz.nifeather.morph.utilities.MathUtils;
 
@@ -13,7 +14,7 @@ import java.util.Map;
 
 public class PhantomProperties extends BaseLivingEntityProperties<Phantom>
 {
-    public final SingleProperty<Integer> SIZE = getSingle("phantom/size", 1);
+    public final SingleProperty<Integer> SIZE = getSingle(PropertyNames.PHANTOM_SIZE, 1);
 
     public PhantomProperties()
     {
@@ -29,7 +30,7 @@ public class PhantomProperties extends BaseLivingEntityProperties<Phantom>
     @Override
     protected @Nullable Pair<SingleProperty<?>, Object> parseSingleInput(String key, String value)
     {
-        if (key.equals(SIZE.id()))
+        if (key.equals(PropertyNames.PHANTOM_SIZE))
         {
             int size = MathUtils.clamp(1, 10, MathUtils.parseIntOr(value, 1));
             return Pair.of(SIZE, size);

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/PhantomProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/PhantomProperties.java
@@ -14,7 +14,7 @@ import java.util.Map;
 
 public class PhantomProperties extends BaseLivingEntityProperties<Phantom>
 {
-    public final SingleProperty<Integer> SIZE = getSingle("size", 1);
+    public final SingleProperty<Integer> SIZE = getSingle("phantom/size", 1);
 
     public PhantomProperties()
     {
@@ -54,7 +54,7 @@ public class PhantomProperties extends BaseLivingEntityProperties<Phantom>
     public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
     {
         return Map.of(
-                "size", propertyHandler.get(SIZE).toString()
+                SIZE.id(), propertyHandler.get(SIZE).toString()
         );
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/PhantomProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/PhantomProperties.java
@@ -1,0 +1,60 @@
+package xyz.nifeather.morph.misc.disguiseProperty.values;
+
+import it.unimi.dsi.fastutil.Pair;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Phantom;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import xyz.nifeather.morph.backends.server.renderer.network.datawatcher.watchers.types.PhantomWatcher;
+import xyz.nifeather.morph.misc.disguiseProperty.PropertyHandler;
+import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
+import xyz.nifeather.morph.utilities.MathUtils;
+
+import java.util.Map;
+
+public class PhantomProperties extends BaseLivingEntityProperties<Phantom>
+{
+    public final SingleProperty<Integer> SIZE = getSingle("size", 1);
+
+    public PhantomProperties()
+    {
+        registerSingle(SIZE);
+    }
+
+    @Override
+    protected @Nullable Phantom tryCastEntity(@Nullable Entity targetEntity)
+    {
+        return targetEntity instanceof Phantom phantom ? phantom : null;
+    }
+
+    @Override
+    protected @Nullable Pair<SingleProperty<?>, Object> parseSingleInput(String key, String value)
+    {
+        if (key.equals(SIZE.id()))
+        {
+            int size = MathUtils.clamp(1, 5, MathUtils.parseIntOr(value, 1));
+            return Pair.of(SIZE, size);
+        }
+
+        return super.parseSingleInput(key, value);
+    }
+
+    @Override
+    protected void setupPropertiesFromEntity(PropertyHandler propertyHandler, @NotNull Phantom targetEntity)
+    {
+        propertyHandler.set(SIZE, targetEntity.getSize());
+    }
+
+    @Override
+    protected void setupDefaultProperties(PropertyHandler propertyHandler)
+    {
+    }
+
+    @Override
+    public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
+    {
+        return Map.of(
+                "size", propertyHandler.get(SIZE).toString()
+        );
+    }
+}

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/PhantomProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/PhantomProperties.java
@@ -50,10 +50,9 @@ public class PhantomProperties extends BaseLivingEntityProperties<Phantom>
     }
 
     @Override
-    public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
+    protected void appendNetworkMap(PropertyHandler propertyHandler, Map<String, String> map)
     {
-        return Map.of(
-                SIZE.id(), propertyHandler.get(SIZE).toString()
-        );
+        super.appendNetworkMap(propertyHandler, map);
+        map.put(SIZE.id(), propertyHandler.get(SIZE).toString());
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/PhantomProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/PhantomProperties.java
@@ -5,7 +5,6 @@ import org.bukkit.entity.Entity;
 import org.bukkit.entity.Phantom;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import xyz.nifeather.morph.backends.server.renderer.network.datawatcher.watchers.types.PhantomWatcher;
 import xyz.nifeather.morph.misc.disguiseProperty.PropertyHandler;
 import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
 import xyz.nifeather.morph.utilities.MathUtils;
@@ -32,7 +31,7 @@ public class PhantomProperties extends BaseLivingEntityProperties<Phantom>
     {
         if (key.equals(SIZE.id()))
         {
-            int size = MathUtils.clamp(1, 5, MathUtils.parseIntOr(value, 1));
+            int size = MathUtils.clamp(1, 10, MathUtils.parseIntOr(value, 1));
             return Pair.of(SIZE, size);
         }
 

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/PigProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/PigProperties.java
@@ -8,6 +8,7 @@ import org.bukkit.entity.Pig;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import xyz.nifeather.morph.misc.disguiseProperty.PropertyHandler;
+import xyz.nifeather.morph.misc.disguiseProperty.PropertyNames;
 import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
 import xyz.nifeather.morph.utilities.DisguiseUtils;
 
@@ -25,7 +26,7 @@ public class PigProperties extends BaseLivingEntityProperties<Pig>
         for (Pig.Variant variant : RegistryAccess.registryAccess().getRegistry(RegistryKey.PIG_VARIANT))
             variantMap.put(variant.key().asString(), variant);
 
-        VARIANT = getSingle("pig/variant", Pig.Variant.TEMPERATE)
+        VARIANT = getSingle(PropertyNames.PIG_VARIANT, Pig.Variant.TEMPERATE)
                 .withRandom(Pig.Variant.TEMPERATE, Pig.Variant.COLD, Pig.Variant.WARM)
                 .withValidInput(variantMap.keySet());
 
@@ -35,7 +36,7 @@ public class PigProperties extends BaseLivingEntityProperties<Pig>
     @Override
     protected @Nullable Pair<SingleProperty<?>, Object> parseSingleInput(String key, String value)
     {
-        if (key.equals(VARIANT.id()))
+        if (key.equals(PropertyNames.PIG_VARIANT))
         {
             var match = variantMap.getOrDefault(value, null);
 

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/PigProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/PigProperties.java
@@ -65,10 +65,9 @@ public class PigProperties extends BaseLivingEntityProperties<Pig>
     }
 
     @Override
-    public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
+    protected void appendNetworkMap(PropertyHandler propertyHandler, Map<String, String> map)
     {
-        return Map.of(
-                VARIANT.id(), propertyHandler.get(VARIANT).key().asString()
-        );
+        super.appendNetworkMap(propertyHandler, map);
+        map.put(VARIANT.id(), propertyHandler.get(VARIANT).key().asString());
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/PigProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/PigProperties.java
@@ -3,14 +3,18 @@ package xyz.nifeather.morph.misc.disguiseProperty.values;
 import io.papermc.paper.registry.RegistryAccess;
 import io.papermc.paper.registry.RegistryKey;
 import it.unimi.dsi.fastutil.Pair;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Pig;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import xyz.nifeather.morph.misc.disguiseProperty.PropertyHandler;
 import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
+import xyz.nifeather.morph.utilities.DisguiseUtils;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-public class PigProperties extends AbstractProperties
+public class PigProperties extends BaseLivingEntityProperties<Pig>
 {
     private final Map<String, Pig.Variant> variantMap = new ConcurrentHashMap<>();
 
@@ -39,6 +43,32 @@ public class PigProperties extends AbstractProperties
                 return Pair.of(VARIANT, match);
         }
 
-        return null;
+        return super.parseSingleInput(key, value);
+    }
+
+    @Override
+    protected @Nullable Pig tryCastEntity(@Nullable Entity targetEntity)
+    {
+        return targetEntity instanceof Pig pig ? pig : null;
+    }
+
+    @Override
+    protected void setupPropertiesFromEntity(PropertyHandler propertyHandler, @NotNull Pig targetEntity)
+    {
+        propertyHandler.set(VARIANT, targetEntity.getVariant());
+    }
+
+    @Override
+    protected void setupDefaultProperties(PropertyHandler propertyHandler)
+    {
+        propertyHandler.set(VARIANT, DisguiseUtils.pick(VARIANT.getRandomValues()));
+    }
+
+    @Override
+    public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
+    {
+        return Map.of(
+                "variant", propertyHandler.get(VARIANT).key().asString()
+        );
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/PigProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/PigProperties.java
@@ -25,7 +25,7 @@ public class PigProperties extends BaseLivingEntityProperties<Pig>
         for (Pig.Variant variant : RegistryAccess.registryAccess().getRegistry(RegistryKey.PIG_VARIANT))
             variantMap.put(variant.key().asString(), variant);
 
-        VARIANT = getSingle("pig_variant", Pig.Variant.TEMPERATE)
+        VARIANT = getSingle("pig/variant", Pig.Variant.TEMPERATE)
                 .withRandom(Pig.Variant.TEMPERATE, Pig.Variant.COLD, Pig.Variant.WARM)
                 .withValidInput(variantMap.keySet());
 
@@ -68,7 +68,7 @@ public class PigProperties extends BaseLivingEntityProperties<Pig>
     public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
     {
         return Map.of(
-                "variant", propertyHandler.get(VARIANT).key().asString()
+                VARIANT.id(), propertyHandler.get(VARIANT).key().asString()
         );
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/PlayerProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/PlayerProperties.java
@@ -8,13 +8,12 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import xyz.nifeather.morph.misc.disguiseProperty.PropertyHandler;
 import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
-import xyz.nifeather.morph.utilities.MathUtils;
 
 import java.util.Map;
 
 public class PlayerProperties extends BaseLivingEntityProperties<Player>
 {
-    public final SingleProperty<MainHandStatus> MAIN_HAND = getSingle("main_hand", MainHandStatus.NOTSET)
+    public final SingleProperty<MainHandStatus> MAIN_HAND = getSingle("player/main_hand", MainHandStatus.NOTSET)
             .withValidInput("left", "right");
 
     public PlayerProperties()
@@ -56,7 +55,8 @@ public class PlayerProperties extends BaseLivingEntityProperties<Player>
     public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
     {
         return Map.of(
-                "main_hand", propertyHandler.get(MAIN_HAND).name().toLowerCase()
+                MAIN_HAND.id(), propertyHandler.get(MAIN_HAND).name().toLowerCase(),
+                STUCKED_ARROWS.id(), propertyHandler.get(STUCKED_ARROWS).toString()
         );
     }
 

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/PlayerProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/PlayerProperties.java
@@ -52,12 +52,11 @@ public class PlayerProperties extends BaseLivingEntityProperties<Player>
     }
 
     @Override
-    public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
+    protected void appendNetworkMap(PropertyHandler propertyHandler, Map<String, String> map)
     {
-        return Map.of(
-                MAIN_HAND.id(), propertyHandler.get(MAIN_HAND).name().toLowerCase(),
-                STUCKED_ARROWS.id(), propertyHandler.get(STUCKED_ARROWS).toString()
-        );
+        super.appendNetworkMap(propertyHandler, map);
+
+        propertyHandler.getOptional(MAIN_HAND).ifPresent(hand -> map.put(MAIN_HAND.id(), hand.name().toLowerCase()));
     }
 
     public enum MainHandStatus

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/PlayerProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/PlayerProperties.java
@@ -7,13 +7,14 @@ import org.bukkit.inventory.MainHand;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import xyz.nifeather.morph.misc.disguiseProperty.PropertyHandler;
+import xyz.nifeather.morph.misc.disguiseProperty.PropertyNames;
 import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
 
 import java.util.Map;
 
 public class PlayerProperties extends BaseLivingEntityProperties<Player>
 {
-    public final SingleProperty<MainHandStatus> MAIN_HAND = getSingle("player/main_hand", MainHandStatus.NOTSET)
+    public final SingleProperty<MainHandStatus> MAIN_HAND = getSingle(PropertyNames.PLAYER_MAIN_HAND, MainHandStatus.NOTSET)
             .withValidInput("left", "right");
 
     public PlayerProperties()
@@ -24,7 +25,7 @@ public class PlayerProperties extends BaseLivingEntityProperties<Player>
     @Override
     protected @Nullable Pair<SingleProperty<?>, Object> parseSingleInput(String key, String value)
     {
-        if (key.equals(MAIN_HAND.id()))
+        if (key.equals(PropertyNames.PLAYER_MAIN_HAND))
         {
             var val = value.equals("left") ? MainHandStatus.LEFT : MainHandStatus.RIGHT;
             return Pair.of(MAIN_HAND, val);

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/PlayerProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/PlayerProperties.java
@@ -1,13 +1,20 @@
 package xyz.nifeather.morph.misc.disguiseProperty.values;
 
 import it.unimi.dsi.fastutil.Pair;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
 import org.bukkit.inventory.MainHand;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import xyz.nifeather.morph.misc.disguiseProperty.PropertyHandler;
 import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
+import xyz.nifeather.morph.utilities.MathUtils;
 
-public class PlayerProperties extends AbstractProperties
+import java.util.Map;
+
+public class PlayerProperties extends BaseLivingEntityProperties<Player>
 {
-    public final SingleProperty<MainHand> MAIN_HAND = getSingle("main_hand", MainHand.RIGHT)
+    public final SingleProperty<MainHandStatus> MAIN_HAND = getSingle("main_hand", MainHandStatus.NOTSET)
             .withValidInput("left", "right");
 
     public PlayerProperties()
@@ -20,10 +27,62 @@ public class PlayerProperties extends AbstractProperties
     {
         if (key.equals(MAIN_HAND.id()))
         {
-            var val = value.equals("left") ? MainHand.LEFT : MainHand.RIGHT;
+            var val = value.equals("left") ? MainHandStatus.LEFT : MainHandStatus.RIGHT;
             return Pair.of(MAIN_HAND, val);
         }
 
-        return null;
+        return super.parseSingleInput(key, value);
+    }
+
+    @Override
+    protected @Nullable Player tryCastEntity(@Nullable Entity targetEntity)
+    {
+        return targetEntity instanceof Player player ? player : null;
+    }
+
+    @Override
+    protected void setupPropertiesFromEntity(PropertyHandler propertyHandler, @NotNull Player targetEntity)
+    {
+        propertyHandler.set(MAIN_HAND, MainHandStatus.fromBukkitHand(targetEntity.getMainHand()));
+        propertyHandler.set(STUCKED_ARROWS, targetEntity.getArrowsInBody());
+    }
+
+    @Override
+    protected void setupDefaultProperties(PropertyHandler propertyHandler)
+    {
+    }
+
+    @Override
+    public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
+    {
+        return Map.of(
+                "main_hand", propertyHandler.get(MAIN_HAND).name().toLowerCase()
+        );
+    }
+
+    public enum MainHandStatus
+    {
+        LEFT(MainHand.LEFT),
+        RIGHT(MainHand.RIGHT),
+        NOTSET(null);
+
+        @Nullable
+        public final MainHand bindingHand;
+
+        MainHandStatus(@Nullable MainHand hand)
+        {
+            this.bindingHand = hand;
+        }
+
+        public static MainHandStatus fromBukkitHand(MainHand hand)
+        {
+            return hand == MainHand.LEFT ? LEFT : RIGHT;
+        }
+
+        @Nullable
+        public MainHand toBukkitHand()
+        {
+            return bindingHand;
+        }
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/RabbitProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/RabbitProperties.java
@@ -67,10 +67,9 @@ public class RabbitProperties extends BaseLivingEntityProperties<Rabbit>
     }
 
     @Override
-    public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
+    protected void appendNetworkMap(PropertyHandler propertyHandler, Map<String, String> map)
     {
-        return Map.of(
-                VARIANT.id(), propertyHandler.get(VARIANT).name().toLowerCase()
-        );
+        super.appendNetworkMap(propertyHandler, map);
+        map.put(VARIANT.id(), propertyHandler.get(VARIANT).name().toLowerCase());
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/RabbitProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/RabbitProperties.java
@@ -7,6 +7,7 @@ import org.bukkit.entity.Rabbit.Type;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import xyz.nifeather.morph.misc.disguiseProperty.PropertyHandler;
+import xyz.nifeather.morph.misc.disguiseProperty.PropertyNames;
 import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
 import xyz.nifeather.morph.utilities.DisguiseUtils;
 
@@ -23,7 +24,7 @@ public class RabbitProperties extends BaseLivingEntityProperties<Rabbit>
             typeMap.put(type.name().toLowerCase(), type);
     }
 
-    public final SingleProperty<Rabbit.Type> VARIANT = getSingle("rabbit/variant", Type.BROWN)
+    public final SingleProperty<Rabbit.Type> VARIANT = getSingle(PropertyNames.RABBIT_VARIANT, Type.BROWN)
             .withRandom(Type.values());
 
     public RabbitProperties()
@@ -37,7 +38,7 @@ public class RabbitProperties extends BaseLivingEntityProperties<Rabbit>
     @Override
     protected @Nullable Pair<SingleProperty<?>, Object> parseSingleInput(String key, String value)
     {
-        if (key.equals(VARIANT.id()))
+        if (key.equals(PropertyNames.RABBIT_VARIANT))
         {
             var variant = typeMap.getOrDefault(value, null);
 

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/RabbitProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/RabbitProperties.java
@@ -1,15 +1,19 @@
 package xyz.nifeather.morph.misc.disguiseProperty.values;
 
 import it.unimi.dsi.fastutil.Pair;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Rabbit;
 import org.bukkit.entity.Rabbit.Type;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import xyz.nifeather.morph.misc.disguiseProperty.PropertyHandler;
 import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
+import xyz.nifeather.morph.utilities.DisguiseUtils;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-public class RabbitProperties extends AbstractProperties
+public class RabbitProperties extends BaseLivingEntityProperties<Rabbit>
 {
     private final Map<String, Type> typeMap = new ConcurrentHashMap<>();
 
@@ -41,6 +45,32 @@ public class RabbitProperties extends AbstractProperties
                 return Pair.of(VARIANT, variant);
         }
 
-        return null;
+        return super.parseSingleInput(key, value);
+    }
+
+    @Override
+    protected @Nullable Rabbit tryCastEntity(@Nullable Entity targetEntity)
+    {
+        return targetEntity instanceof Rabbit rabbit ? rabbit : null;
+    }
+
+    @Override
+    protected void setupPropertiesFromEntity(PropertyHandler propertyHandler, @NotNull Rabbit targetEntity)
+    {
+        propertyHandler.set(VARIANT, targetEntity.getRabbitType());
+    }
+
+    @Override
+    protected void setupDefaultProperties(PropertyHandler propertyHandler)
+    {
+        propertyHandler.set(VARIANT, DisguiseUtils.pick(VARIANT.getRandomValues()));
+    }
+
+    @Override
+    public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
+    {
+        return Map.of(
+                "variant", propertyHandler.get(VARIANT).name().toLowerCase()
+        );
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/RabbitProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/RabbitProperties.java
@@ -23,7 +23,7 @@ public class RabbitProperties extends BaseLivingEntityProperties<Rabbit>
             typeMap.put(type.name().toLowerCase(), type);
     }
 
-    public final SingleProperty<Rabbit.Type> VARIANT = getSingle("rabbit_type", Type.BROWN)
+    public final SingleProperty<Rabbit.Type> VARIANT = getSingle("rabbit/variant", Type.BROWN)
             .withRandom(Type.values());
 
     public RabbitProperties()
@@ -70,7 +70,7 @@ public class RabbitProperties extends BaseLivingEntityProperties<Rabbit>
     public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
     {
         return Map.of(
-                "variant", propertyHandler.get(VARIANT).name().toLowerCase()
+                VARIANT.id(), propertyHandler.get(VARIANT).name().toLowerCase()
         );
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/SheepProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/SheepProperties.java
@@ -1,0 +1,67 @@
+package xyz.nifeather.morph.misc.disguiseProperty.values;
+
+import it.unimi.dsi.fastutil.Pair;
+import org.bukkit.DyeColor;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Sheep;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import xyz.nifeather.morph.misc.disguiseProperty.PropertyHandler;
+import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
+
+import java.util.Arrays;
+import java.util.Map;
+
+public class SheepProperties extends BaseLivingEntityProperties<Sheep>
+{
+    public final SingleProperty<DyeColor> DYE_COLOR = getSingle("dye_color", DyeColor.getByWoolData((byte)15));
+
+    public SheepProperties()
+    {
+        DYE_COLOR.withValidInput(Arrays.stream(DyeColor.values()).map(c -> c.name().toLowerCase()).toList());
+        registerSingle(DYE_COLOR);
+    }
+
+    @Override
+    protected @Nullable Sheep tryCastEntity(@Nullable Entity targetEntity)
+    {
+        return targetEntity instanceof Sheep sheep ? sheep : null;
+    }
+
+    @Override
+    protected @Nullable Pair<SingleProperty<?>, Object> parseSingleInput(String key, String value)
+    {
+        if (key.equals(DYE_COLOR.id()))
+        {
+            var match = Arrays.stream(DyeColor.values()).filter(v -> v.name().equalsIgnoreCase(value))
+                    .findFirst().orElse(null);
+
+            if (match == null)
+                return null;
+
+            return Pair.of(DYE_COLOR, match);
+        }
+
+        return super.parseSingleInput(key, value);
+    }
+
+    @Override
+    protected void setupPropertiesFromEntity(PropertyHandler propertyHandler, @NotNull Sheep targetEntity)
+    {
+        if (targetEntity.getColor() != null)
+            propertyHandler.set(DYE_COLOR, targetEntity.getColor());
+    }
+
+    @Override
+    protected void setupDefaultProperties(PropertyHandler propertyHandler)
+    {
+    }
+
+    @Override
+    public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
+    {
+        return Map.of(
+                "dye_color", propertyHandler.get(DYE_COLOR).name().toLowerCase()
+        );
+    }
+}

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/SheepProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/SheepProperties.java
@@ -14,7 +14,7 @@ import java.util.Map;
 
 public class SheepProperties extends BaseLivingEntityProperties<Sheep>
 {
-    public final SingleProperty<DyeColor> DYE_COLOR = getSingle("dye_color", DyeColor.getByWoolData((byte)15));
+    public final SingleProperty<DyeColor> DYE_COLOR = getSingle("sheep/color", DyeColor.getByWoolData((byte)15));
 
     public SheepProperties()
     {
@@ -61,7 +61,7 @@ public class SheepProperties extends BaseLivingEntityProperties<Sheep>
     public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
     {
         return Map.of(
-                "dye_color", propertyHandler.get(DYE_COLOR).name().toLowerCase()
+                DYE_COLOR.id(), propertyHandler.get(DYE_COLOR).name().toLowerCase()
         );
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/SheepProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/SheepProperties.java
@@ -7,6 +7,7 @@ import org.bukkit.entity.Sheep;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import xyz.nifeather.morph.misc.disguiseProperty.PropertyHandler;
+import xyz.nifeather.morph.misc.disguiseProperty.PropertyNames;
 import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
 
 import java.util.Arrays;
@@ -14,7 +15,7 @@ import java.util.Map;
 
 public class SheepProperties extends BaseLivingEntityProperties<Sheep>
 {
-    public final SingleProperty<DyeColor> DYE_COLOR = getSingle("sheep/color", DyeColor.getByWoolData((byte)15));
+    public final SingleProperty<DyeColor> DYE_COLOR = getSingle(PropertyNames.SHEEP_COLOR, DyeColor.getByWoolData((byte)15));
 
     public SheepProperties()
     {
@@ -31,7 +32,7 @@ public class SheepProperties extends BaseLivingEntityProperties<Sheep>
     @Override
     protected @Nullable Pair<SingleProperty<?>, Object> parseSingleInput(String key, String value)
     {
-        if (key.equals(DYE_COLOR.id()))
+        if (key.equals(PropertyNames.SHEEP_COLOR))
         {
             var match = Arrays.stream(DyeColor.values()).filter(v -> v.name().equalsIgnoreCase(value))
                     .findFirst().orElse(null);

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/SheepProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/SheepProperties.java
@@ -58,10 +58,9 @@ public class SheepProperties extends BaseLivingEntityProperties<Sheep>
     }
 
     @Override
-    public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
+    protected void appendNetworkMap(PropertyHandler propertyHandler, Map<String, String> map)
     {
-        return Map.of(
-                DYE_COLOR.id(), propertyHandler.get(DYE_COLOR).name().toLowerCase()
-        );
+        super.appendNetworkMap(propertyHandler, map);
+        map.put(DYE_COLOR.id(), propertyHandler.get(DYE_COLOR).name().toLowerCase());
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/ShulkerProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/ShulkerProperties.java
@@ -1,0 +1,67 @@
+package xyz.nifeather.morph.misc.disguiseProperty.values;
+
+import it.unimi.dsi.fastutil.Pair;
+import org.bukkit.DyeColor;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Shulker;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import xyz.nifeather.morph.misc.disguiseProperty.PropertyHandler;
+import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
+
+import java.util.Arrays;
+import java.util.Map;
+
+public class ShulkerProperties extends BaseLivingEntityProperties<Shulker>
+{
+    public final SingleProperty<DyeColor> DYE_COLOR = getSingle("shulker_color", DyeColor.getByWoolData((byte)15));
+
+    public ShulkerProperties()
+    {
+        DYE_COLOR.withValidInput(Arrays.stream(DyeColor.values()).map(c -> c.name().toLowerCase()).toList());
+        registerSingle(DYE_COLOR);
+    }
+
+    @Override
+    protected @Nullable Shulker tryCastEntity(@Nullable Entity targetEntity)
+    {
+        return targetEntity instanceof Shulker shulker ? shulker : null;
+    }
+
+    @Override
+    protected @Nullable Pair<SingleProperty<?>, Object> parseSingleInput(String key, String value)
+    {
+        if (key.equals(DYE_COLOR.id()))
+        {
+            var match = Arrays.stream(DyeColor.values()).filter(v -> v.name().equalsIgnoreCase(value))
+                    .findFirst().orElse(null);
+
+            if (match == null)
+                return null;
+
+            return Pair.of(DYE_COLOR, match);
+        }
+
+        return super.parseSingleInput(key, value);
+    }
+
+    @Override
+    protected void setupPropertiesFromEntity(PropertyHandler propertyHandler, @NotNull Shulker targetEntity)
+    {
+        if (targetEntity.getColor() != null)
+            propertyHandler.set(DYE_COLOR, targetEntity.getColor());
+    }
+
+    @Override
+    protected void setupDefaultProperties(PropertyHandler propertyHandler)
+    {
+    }
+
+    @Override
+    public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
+    {
+        return Map.of(
+                "dye_color", propertyHandler.get(DYE_COLOR).name().toLowerCase()
+        );
+    }
+}

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/ShulkerProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/ShulkerProperties.java
@@ -60,8 +60,8 @@ public class ShulkerProperties extends BaseLivingEntityProperties<Shulker>
     @Override
     public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
     {
-        return Map.of(
-                DYE_COLOR.id(), propertyHandler.get(DYE_COLOR).name().toLowerCase()
-        );
+        return propertyHandler.contains(DYE_COLOR)
+                ? Map.of(DYE_COLOR.id(), propertyHandler.get(DYE_COLOR).name().toLowerCase())
+                : Map.of();
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/ShulkerProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/ShulkerProperties.java
@@ -14,7 +14,7 @@ import java.util.Map;
 
 public class ShulkerProperties extends BaseLivingEntityProperties<Shulker>
 {
-    public final SingleProperty<DyeColor> DYE_COLOR = getSingle("shulker_color", DyeColor.getByWoolData((byte)15));
+    public final SingleProperty<DyeColor> DYE_COLOR = getSingle("shulker/color", DyeColor.getByWoolData((byte)15));
 
     public ShulkerProperties()
     {
@@ -61,7 +61,7 @@ public class ShulkerProperties extends BaseLivingEntityProperties<Shulker>
     public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
     {
         return Map.of(
-                "dye_color", propertyHandler.get(DYE_COLOR).name().toLowerCase()
+                DYE_COLOR.id(), propertyHandler.get(DYE_COLOR).name().toLowerCase()
         );
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/ShulkerProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/ShulkerProperties.java
@@ -58,10 +58,9 @@ public class ShulkerProperties extends BaseLivingEntityProperties<Shulker>
     }
 
     @Override
-    public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
+    protected void appendNetworkMap(PropertyHandler propertyHandler, Map<String, String> map)
     {
-        return propertyHandler.contains(DYE_COLOR)
-                ? Map.of(DYE_COLOR.id(), propertyHandler.get(DYE_COLOR).name().toLowerCase())
-                : Map.of();
+        super.appendNetworkMap(propertyHandler, map);
+        propertyHandler.getOptional(DYE_COLOR).ifPresent(v -> map.put(DYE_COLOR.id(), v.name().toLowerCase()));
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/ShulkerProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/ShulkerProperties.java
@@ -7,6 +7,7 @@ import org.bukkit.entity.Shulker;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import xyz.nifeather.morph.misc.disguiseProperty.PropertyHandler;
+import xyz.nifeather.morph.misc.disguiseProperty.PropertyNames;
 import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
 
 import java.util.Arrays;
@@ -14,7 +15,7 @@ import java.util.Map;
 
 public class ShulkerProperties extends BaseLivingEntityProperties<Shulker>
 {
-    public final SingleProperty<DyeColor> DYE_COLOR = getSingle("shulker/color", DyeColor.getByWoolData((byte)15));
+    public final SingleProperty<DyeColor> DYE_COLOR = getSingle(PropertyNames.SHULKER_COLOR, DyeColor.getByWoolData((byte)15));
 
     public ShulkerProperties()
     {
@@ -31,7 +32,7 @@ public class ShulkerProperties extends BaseLivingEntityProperties<Shulker>
     @Override
     protected @Nullable Pair<SingleProperty<?>, Object> parseSingleInput(String key, String value)
     {
-        if (key.equals(DYE_COLOR.id()))
+        if (key.equals(PropertyNames.SHULKER_COLOR))
         {
             var match = Arrays.stream(DyeColor.values()).filter(v -> v.name().equalsIgnoreCase(value))
                     .findFirst().orElse(null);

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/SlimeMagmaProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/SlimeMagmaProperties.java
@@ -55,10 +55,9 @@ public class SlimeMagmaProperties extends BaseLivingEntityProperties<Slime>
     }
 
     @Override
-    public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
+    protected void appendNetworkMap(PropertyHandler propertyHandler, Map<String, String> map)
     {
-        return Map.of(
-                SIZE.id(), propertyHandler.getOr(SIZE, 1).toString()
-        );
+        super.appendNetworkMap(propertyHandler, map);
+        map.put(SIZE.id(), propertyHandler.getOr(SIZE, 1).toString());
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/SlimeMagmaProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/SlimeMagmaProperties.java
@@ -8,6 +8,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import xyz.nifeather.morph.misc.DisguiseState;
 import xyz.nifeather.morph.misc.disguiseProperty.PropertyHandler;
+import xyz.nifeather.morph.misc.disguiseProperty.PropertyNames;
 import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
 import xyz.nifeather.morph.utilities.MathUtils;
 
@@ -17,7 +18,7 @@ import java.util.concurrent.ThreadLocalRandom;
 
 public class SlimeMagmaProperties extends BaseLivingEntityProperties<Slime>
 {
-    public final SingleProperty<Integer> SIZE = getSingle("slime_magma/size", 1);
+    public final SingleProperty<Integer> SIZE = getSingle(PropertyNames.SLIME_MAGMA_SIZE, 1);
 
     public SlimeMagmaProperties()
     {
@@ -27,7 +28,7 @@ public class SlimeMagmaProperties extends BaseLivingEntityProperties<Slime>
     @Override
     protected @Nullable Pair<SingleProperty<?>, Object> parseSingleInput(String key, String value)
     {
-        if (key.equals(SIZE.id()))
+        if (key.equals(PropertyNames.SLIME_MAGMA_SIZE))
         {
             int size = MathUtils.clamp(1, 4, MathUtils.parseIntOr(value, 1));
             return Pair.of(SIZE, size);

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/SlimeMagmaProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/SlimeMagmaProperties.java
@@ -17,7 +17,7 @@ import java.util.concurrent.ThreadLocalRandom;
 
 public class SlimeMagmaProperties extends BaseLivingEntityProperties<Slime>
 {
-    public final SingleProperty<Integer> SIZE = getSingle("slime_magma_size", 1);
+    public final SingleProperty<Integer> SIZE = getSingle("slime_magma/size", 1);
 
     public SlimeMagmaProperties()
     {
@@ -58,7 +58,7 @@ public class SlimeMagmaProperties extends BaseLivingEntityProperties<Slime>
     public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
     {
         return Map.of(
-                "size", propertyHandler.getOr(SIZE, 1).toString()
+                SIZE.id(), propertyHandler.getOr(SIZE, 1).toString()
         );
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/SlimeMagmaProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/SlimeMagmaProperties.java
@@ -1,0 +1,64 @@
+package xyz.nifeather.morph.misc.disguiseProperty.values;
+
+import it.unimi.dsi.fastutil.Pair;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Slime;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import xyz.nifeather.morph.misc.DisguiseState;
+import xyz.nifeather.morph.misc.disguiseProperty.PropertyHandler;
+import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
+import xyz.nifeather.morph.utilities.MathUtils;
+
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
+
+public class SlimeMagmaProperties extends BaseLivingEntityProperties<Slime>
+{
+    public final SingleProperty<Integer> SIZE = getSingle("slime_magma_size", 1);
+
+    public SlimeMagmaProperties()
+    {
+        registerSingle(SIZE);
+    }
+
+    @Override
+    protected @Nullable Pair<SingleProperty<?>, Object> parseSingleInput(String key, String value)
+    {
+        if (key.equals(SIZE.id()))
+        {
+            int size = MathUtils.clamp(1, 4, MathUtils.parseIntOr(value, 1));
+            return Pair.of(SIZE, size);
+        }
+
+        return super.parseSingleInput(key, value);
+    }
+
+    @Override
+    protected @Nullable Slime tryCastEntity(@Nullable Entity targetEntity)
+    {
+        return targetEntity instanceof Slime slime ? slime : null;
+    }
+
+    @Override
+    protected void setupPropertiesFromEntity(PropertyHandler propertyHandler, @NotNull Slime targetEntity)
+    {
+        propertyHandler.set(SIZE, targetEntity.getSize());
+    }
+
+    @Override
+    protected void setupDefaultProperties(PropertyHandler propertyHandler)
+    {
+        propertyHandler.set(SIZE, ThreadLocalRandom.current().nextInt(0, 4));
+    }
+
+    @Override
+    public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
+    {
+        return Map.of(
+                "size", propertyHandler.getOr(SIZE, 1).toString()
+        );
+    }
+}

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/SnowGolemProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/SnowGolemProperties.java
@@ -49,10 +49,9 @@ public class SnowGolemProperties extends BaseLivingEntityProperties<Snowman>
     }
 
     @Override
-    public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
+    protected void appendNetworkMap(PropertyHandler propertyHandler, Map<String, String> map)
     {
-        return Map.of(
-                HAS_PUMPKIN.id(), propertyHandler.get(HAS_PUMPKIN).toString().toLowerCase()
-        );
+        super.appendNetworkMap(propertyHandler, map);
+        map.put(HAS_PUMPKIN.id(), propertyHandler.get(HAS_PUMPKIN).toString().toLowerCase());
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/SnowGolemProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/SnowGolemProperties.java
@@ -1,0 +1,58 @@
+package xyz.nifeather.morph.misc.disguiseProperty.values;
+
+import it.unimi.dsi.fastutil.Pair;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Snowman;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import xyz.nifeather.morph.backends.server.renderer.network.datawatcher.watchers.types.SnowGolemWatcher;
+import xyz.nifeather.morph.misc.disguiseProperty.PropertyHandler;
+import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
+
+import java.util.Map;
+
+public class SnowGolemProperties extends BaseLivingEntityProperties<Snowman>
+{
+    public final SingleProperty<Boolean> HAS_PUMPKIN = getSingle("has_pumpkin", true);
+
+    public SnowGolemProperties()
+    {
+        registerSingle(HAS_PUMPKIN);
+    }
+
+    @Override
+    protected @Nullable Snowman tryCastEntity(@Nullable Entity targetEntity)
+    {
+        return targetEntity instanceof Snowman snowman ? snowman : null;
+    }
+
+    @Override
+    protected void setupPropertiesFromEntity(PropertyHandler propertyHandler, @NotNull Snowman targetEntity)
+    {
+        propertyHandler.set(HAS_PUMPKIN, !targetEntity.isDerp());
+    }
+
+    @Override
+    protected @Nullable Pair<SingleProperty<?>, Object> parseSingleInput(String key, String value)
+    {
+        if (key.equals(HAS_PUMPKIN.id()))
+        {
+            return Pair.of(HAS_PUMPKIN, Boolean.valueOf(value));
+        }
+
+        return super.parseSingleInput(key, value);
+    }
+
+    @Override
+    protected void setupDefaultProperties(PropertyHandler propertyHandler)
+    {
+    }
+
+    @Override
+    public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
+    {
+        return Map.of(
+                "has_pumpkin", propertyHandler.get(HAS_PUMPKIN).toString().toLowerCase()
+        );
+    }
+}

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/SnowGolemProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/SnowGolemProperties.java
@@ -13,7 +13,7 @@ import java.util.Map;
 
 public class SnowGolemProperties extends BaseLivingEntityProperties<Snowman>
 {
-    public final SingleProperty<Boolean> HAS_PUMPKIN = getSingle("has_pumpkin", true);
+    public final SingleProperty<Boolean> HAS_PUMPKIN = getSingle("snow_golem/pumpkin", true);
 
     public SnowGolemProperties()
     {
@@ -52,7 +52,7 @@ public class SnowGolemProperties extends BaseLivingEntityProperties<Snowman>
     public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
     {
         return Map.of(
-                "has_pumpkin", propertyHandler.get(HAS_PUMPKIN).toString().toLowerCase()
+                HAS_PUMPKIN.id(), propertyHandler.get(HAS_PUMPKIN).toString().toLowerCase()
         );
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/SnowGolemProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/SnowGolemProperties.java
@@ -7,13 +7,14 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import xyz.nifeather.morph.backends.server.renderer.network.datawatcher.watchers.types.SnowGolemWatcher;
 import xyz.nifeather.morph.misc.disguiseProperty.PropertyHandler;
+import xyz.nifeather.morph.misc.disguiseProperty.PropertyNames;
 import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
 
 import java.util.Map;
 
 public class SnowGolemProperties extends BaseLivingEntityProperties<Snowman>
 {
-    public final SingleProperty<Boolean> HAS_PUMPKIN = getSingle("snow_golem/pumpkin", true);
+    public final SingleProperty<Boolean> HAS_PUMPKIN = getSingle(PropertyNames.SNOW_GOLEM_HAS_PUMPKIN, true);
 
     public SnowGolemProperties()
     {
@@ -35,7 +36,7 @@ public class SnowGolemProperties extends BaseLivingEntityProperties<Snowman>
     @Override
     protected @Nullable Pair<SingleProperty<?>, Object> parseSingleInput(String key, String value)
     {
-        if (key.equals(HAS_PUMPKIN.id()))
+        if (key.equals(PropertyNames.SNOW_GOLEM_HAS_PUMPKIN))
         {
             return Pair.of(HAS_PUMPKIN, Boolean.valueOf(value));
         }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/TraderLlamaProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/TraderLlamaProperties.java
@@ -1,0 +1,5 @@
+package xyz.nifeather.morph.misc.disguiseProperty.values;
+
+public class TraderLlamaProperties extends LlamaProperties
+{
+}

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/TropicalFishProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/TropicalFishProperties.java
@@ -14,7 +14,7 @@ import java.util.Map;
 
 public class TropicalFishProperties extends BaseLivingEntityProperties<TropicalFish>
 {
-    public final SingleProperty<Integer> VARIANT = getSingle("tropical_fish_variant", 0);
+    public final SingleProperty<Integer> VARIANT = getSingle("tropical_fish/variant", 0);
 
     public TropicalFishProperties()
     {
@@ -56,7 +56,7 @@ public class TropicalFishProperties extends BaseLivingEntityProperties<TropicalF
     public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
     {
         return Map.of(
-                "variant", propertyHandler.get(VARIANT).toString()
+                    VARIANT.id(), propertyHandler.get(VARIANT).toString()
         );
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/TropicalFishProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/TropicalFishProperties.java
@@ -1,7 +1,7 @@
 package xyz.nifeather.morph.misc.disguiseProperty.values;
 
+import it.unimi.dsi.fastutil.Pair;
 import org.bukkit.DyeColor;
-import org.bukkit.craftbukkit.entity.CraftTropicalFish;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.TropicalFish;
 import org.jetbrains.annotations.NotNull;
@@ -10,15 +10,69 @@ import xyz.nifeather.morph.misc.disguiseProperty.PropertyHandler;
 import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
 import xyz.nifeather.morph.utilities.DisguiseUtils;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 
 public class TropicalFishProperties extends BaseLivingEntityProperties<TropicalFish>
 {
-    public final SingleProperty<Integer> VARIANT = getSingle("tropical_fish/variant", 0);
+    public final SingleProperty<DyeColor> BODY_COLOR = getSingle("tropical_fish/body_color", DyeColor.GREEN)
+            .withRandom(DyeColor.values());
+    public final SingleProperty<DyeColor> PATTERN_COLOR = getSingle("tropical_fish/pattern_color", DyeColor.BLACK)
+            .withRandom(DyeColor.values());
+    public final SingleProperty<TropicalFish.Pattern> PATTERN = getSingle("tropical_fish/pattern", TropicalFish.Pattern.BLOCKFISH)
+            .withRandom(TropicalFish.Pattern.values());
 
     public TropicalFishProperties()
     {
-        registerSingle(VARIANT);
+        List<String> dyeColorInputs = Arrays.stream(DyeColor.values())
+                .map(c -> c.name().toLowerCase())
+                .toList();
+
+        BODY_COLOR.withValidInput(dyeColorInputs);
+        PATTERN_COLOR.withValidInput(dyeColorInputs);
+        PATTERN.withValidInput(Arrays.stream(TropicalFish.Pattern.values()).map(p -> p.name().toLowerCase()).toList());
+
+        registerSingle(BODY_COLOR, PATTERN_COLOR, PATTERN);
+    }
+
+    @Override
+    protected @Nullable Pair<SingleProperty<?>, Object> parseSingleInput(String key, String value)
+    {
+        logger.info("Input! key is %s and value is %s".formatted(key, value));
+        if (key.equals(BODY_COLOR.id()))
+        {
+            var match = Arrays.stream(DyeColor.values())
+                    .filter(c -> c.name().equalsIgnoreCase(value))
+                    .findFirst().orElse(null);
+
+            logger.info("BODY COILOR get " + match);
+            if (match == null) return null;
+
+            return Pair.of(BODY_COLOR, match);
+        }
+        else if (key.equals(PATTERN_COLOR.id()))
+        {
+            var match = Arrays.stream(DyeColor.values())
+                    .filter(c -> c.name().equalsIgnoreCase(value))
+                    .findFirst().orElse(null);
+
+            if (match == null) return null;
+
+            return Pair.of(PATTERN_COLOR, match);
+        }
+        else if (key.equals(PATTERN.id()))
+        {
+            var match = Arrays.stream(TropicalFish.Pattern.values())
+                    .filter(p -> p.name().equalsIgnoreCase(value))
+                    .findFirst().orElse(null);
+
+            if (match == null) return null;
+
+            return Pair.of(PATTERN, match);
+        }
+
+        return super.parseSingleInput(key, value);
     }
 
     @Override
@@ -34,29 +88,30 @@ public class TropicalFishProperties extends BaseLivingEntityProperties<TropicalF
         var patternColor = targetEntity.getPatternColor();
         var pattern = targetEntity.getPattern();
 
-        // todo: We might want to replace this CraftBukkit call
-        int packed = CraftTropicalFish.getData(patternColor, bodyColor, pattern);
-
-        propertyHandler.set(VARIANT, packed);
+        propertyHandler.set(PATTERN_COLOR, patternColor);
+        propertyHandler.set(BODY_COLOR, bodyColor);
+        propertyHandler.set(PATTERN, pattern);
     }
 
     @Override
     protected void setupDefaultProperties(PropertyHandler propertyHandler)
     {
-        var bodyColor = DisguiseUtils.pick(DyeColor.values());
-        var patternColor = DisguiseUtils.pick(DyeColor.values());
-        var pattern = DisguiseUtils.pick(TropicalFish.Pattern.values());
+        var bodyColor = DisguiseUtils.pick(BODY_COLOR.getRandomValues());
+        var patternColor = DisguiseUtils.pick(PATTERN_COLOR.getRandomValues());
+        var pattern = DisguiseUtils.pick(PATTERN.getRandomValues());
 
-        int packed = CraftTropicalFish.getData(patternColor, bodyColor, pattern);
-
-        propertyHandler.set(VARIANT, packed);
+        propertyHandler.set(BODY_COLOR, bodyColor);
+        propertyHandler.set(PATTERN_COLOR, patternColor);
+        propertyHandler.set(PATTERN, pattern);
     }
 
     @Override
     public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
     {
         return Map.of(
-                    VARIANT.id(), propertyHandler.get(VARIANT).toString()
+                BODY_COLOR.id(), propertyHandler.get(BODY_COLOR).name().toLowerCase(),
+                PATTERN_COLOR.id(), propertyHandler.get(PATTERN_COLOR).name().toLowerCase(),
+                PATTERN.id(), propertyHandler.get(PATTERN).name().toLowerCase()
         );
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/TropicalFishProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/TropicalFishProperties.java
@@ -1,0 +1,62 @@
+package xyz.nifeather.morph.misc.disguiseProperty.values;
+
+import org.bukkit.DyeColor;
+import org.bukkit.craftbukkit.entity.CraftTropicalFish;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.TropicalFish;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import xyz.nifeather.morph.misc.disguiseProperty.PropertyHandler;
+import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
+import xyz.nifeather.morph.utilities.DisguiseUtils;
+
+import java.util.Map;
+
+public class TropicalFishProperties extends BaseLivingEntityProperties<TropicalFish>
+{
+    public final SingleProperty<Integer> VARIANT = getSingle("tropical_fish_variant", 0);
+
+    public TropicalFishProperties()
+    {
+        registerSingle(VARIANT);
+    }
+
+    @Override
+    protected @Nullable TropicalFish tryCastEntity(@Nullable Entity targetEntity)
+    {
+        return targetEntity instanceof TropicalFish tropicalFish ? tropicalFish : null;
+    }
+
+    @Override
+    protected void setupPropertiesFromEntity(PropertyHandler propertyHandler, @NotNull TropicalFish targetEntity)
+    {
+        var bodyColor = targetEntity.getBodyColor();
+        var patternColor = targetEntity.getPatternColor();
+        var pattern = targetEntity.getPattern();
+
+        // todo: We might want to replace this CraftBukkit call
+        int packed = CraftTropicalFish.getData(patternColor, bodyColor, pattern);
+
+        propertyHandler.set(VARIANT, packed);
+    }
+
+    @Override
+    protected void setupDefaultProperties(PropertyHandler propertyHandler)
+    {
+        var bodyColor = DisguiseUtils.pick(DyeColor.values());
+        var patternColor = DisguiseUtils.pick(DyeColor.values());
+        var pattern = DisguiseUtils.pick(TropicalFish.Pattern.values());
+
+        int packed = CraftTropicalFish.getData(patternColor, bodyColor, pattern);
+
+        propertyHandler.set(VARIANT, packed);
+    }
+
+    @Override
+    public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
+    {
+        return Map.of(
+                "variant", propertyHandler.get(VARIANT).toString()
+        );
+    }
+}

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/TropicalFishProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/TropicalFishProperties.java
@@ -106,12 +106,12 @@ public class TropicalFishProperties extends BaseLivingEntityProperties<TropicalF
     }
 
     @Override
-    public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
+    protected void appendNetworkMap(PropertyHandler propertyHandler, Map<String, String> map)
     {
-        return Map.of(
-                BODY_COLOR.id(), propertyHandler.get(BODY_COLOR).name().toLowerCase(),
-                PATTERN_COLOR.id(), propertyHandler.get(PATTERN_COLOR).name().toLowerCase(),
-                PATTERN.id(), propertyHandler.get(PATTERN).name().toLowerCase()
-        );
+        super.appendNetworkMap(propertyHandler, map);
+
+        map.put(BODY_COLOR.id(), propertyHandler.get(BODY_COLOR).name().toLowerCase());
+        map.put(PATTERN_COLOR.id(), propertyHandler.get(PATTERN_COLOR).name().toLowerCase());
+        map.put(PATTERN.id(), propertyHandler.get(PATTERN).name().toLowerCase());
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/TropicalFishProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/TropicalFishProperties.java
@@ -7,6 +7,7 @@ import org.bukkit.entity.TropicalFish;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import xyz.nifeather.morph.misc.disguiseProperty.PropertyHandler;
+import xyz.nifeather.morph.misc.disguiseProperty.PropertyNames;
 import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
 import xyz.nifeather.morph.utilities.DisguiseUtils;
 
@@ -16,11 +17,11 @@ import java.util.Map;
 
 public class TropicalFishProperties extends BaseLivingEntityProperties<TropicalFish>
 {
-    public final SingleProperty<DyeColor> BODY_COLOR = getSingle("tropical_fish/body_color", DyeColor.GREEN)
+    public final SingleProperty<DyeColor> BODY_COLOR = getSingle(PropertyNames.TROPICAL_FISH_BODY_COLOR, DyeColor.GREEN)
             .withRandom(DyeColor.values());
-    public final SingleProperty<DyeColor> PATTERN_COLOR = getSingle("tropical_fish/pattern_color", DyeColor.BLACK)
+    public final SingleProperty<DyeColor> PATTERN_COLOR = getSingle(PropertyNames.TROPICAL_FISH_PATTERN_COLOR, DyeColor.BLACK)
             .withRandom(DyeColor.values());
-    public final SingleProperty<TropicalFish.Pattern> PATTERN = getSingle("tropical_fish/pattern", TropicalFish.Pattern.BLOCKFISH)
+    public final SingleProperty<TropicalFish.Pattern> PATTERN = getSingle(PropertyNames.TROPICAL_FISH_PATTERN, TropicalFish.Pattern.BLOCKFISH)
             .withRandom(TropicalFish.Pattern.values());
 
     public TropicalFishProperties()
@@ -39,40 +40,43 @@ public class TropicalFishProperties extends BaseLivingEntityProperties<TropicalF
     @Override
     protected @Nullable Pair<SingleProperty<?>, Object> parseSingleInput(String key, String value)
     {
-        logger.info("Input! key is %s and value is %s".formatted(key, value));
-        if (key.equals(BODY_COLOR.id()))
+        return switch (key)
         {
-            var match = Arrays.stream(DyeColor.values())
-                    .filter(c -> c.name().equalsIgnoreCase(value))
-                    .findFirst().orElse(null);
+            case PropertyNames.TROPICAL_FISH_BODY_COLOR ->
+            {
+                var match = Arrays.stream(DyeColor.values())
+                        .filter(c -> c.name().equalsIgnoreCase(value))
+                        .findFirst().orElse(null);
 
-            logger.info("BODY COILOR get " + match);
-            if (match == null) return null;
+                if (match == null) yield null;
 
-            return Pair.of(BODY_COLOR, match);
-        }
-        else if (key.equals(PATTERN_COLOR.id()))
-        {
-            var match = Arrays.stream(DyeColor.values())
-                    .filter(c -> c.name().equalsIgnoreCase(value))
-                    .findFirst().orElse(null);
+                yield  Pair.of(BODY_COLOR, match);
+            }
 
-            if (match == null) return null;
+            case PropertyNames.TROPICAL_FISH_PATTERN_COLOR ->
+            {
+                var match = Arrays.stream(DyeColor.values())
+                        .filter(c -> c.name().equalsIgnoreCase(value))
+                        .findFirst().orElse(null);
 
-            return Pair.of(PATTERN_COLOR, match);
-        }
-        else if (key.equals(PATTERN.id()))
-        {
-            var match = Arrays.stream(TropicalFish.Pattern.values())
-                    .filter(p -> p.name().equalsIgnoreCase(value))
-                    .findFirst().orElse(null);
+                if (match == null) yield null;
 
-            if (match == null) return null;
+                yield Pair.of(PATTERN_COLOR, match);
+            }
 
-            return Pair.of(PATTERN, match);
-        }
+            case PropertyNames.TROPICAL_FISH_PATTERN ->
+            {
+                var match = Arrays.stream(TropicalFish.Pattern.values())
+                        .filter(p -> p.name().equalsIgnoreCase(value))
+                        .findFirst().orElse(null);
 
-        return super.parseSingleInput(key, value);
+                if (match == null) yield null;
+
+                yield Pair.of(PATTERN, match);
+            }
+
+            default -> super.parseSingleInput(key, value);
+        };
     }
 
     @Override

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/VillagerProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/VillagerProperties.java
@@ -112,12 +112,11 @@ public class VillagerProperties extends BaseLivingEntityProperties<Villager>
     }
 
     @Override
-    public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
+    protected void appendNetworkMap(PropertyHandler propertyHandler, Map<String, String> map)
     {
-        return Map.of(
-                TYPE.id(), propertyHandler.get(TYPE).key().asString(),
-                PROFESSION.id(), propertyHandler.get(PROFESSION).key().asString(),
-                LEVEL.id(), propertyHandler.get(LEVEL) + ""
-        );
+        super.appendNetworkMap(propertyHandler, map);
+        map.put(TYPE.id(), propertyHandler.get(TYPE).key().asString());
+        map.put(PROFESSION.id(), propertyHandler.get(PROFESSION).key().asString());
+        map.put(LEVEL.id(), propertyHandler.get(LEVEL) + "");
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/VillagerProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/VillagerProperties.java
@@ -28,13 +28,13 @@ public class VillagerProperties extends BaseLivingEntityProperties<Villager>
             professionMap.put(profession.key().asString(), profession);
     }
 
-    public final SingleProperty<Villager.Type> TYPE = getSingle("villager_type", Villager.Type.PLAINS)
+    public final SingleProperty<Villager.Type> TYPE = getSingle("villager/type", Villager.Type.PLAINS)
             .withRandom(Registry.VILLAGER_TYPE.stream().toList());
 
-    public final SingleProperty<Villager.Profession> PROFESSION = getSingle("villager_profession", Villager.Profession.NONE)
+    public final SingleProperty<Villager.Profession> PROFESSION = getSingle("villager/profession", Villager.Profession.NONE)
             .withRandom(Registry.VILLAGER_PROFESSION.stream().toList());
 
-    public final SingleProperty<Integer> LEVEL = getSingle("villager_level", 1)
+    public final SingleProperty<Integer> LEVEL = getSingle("villager/level", 1)
             .withRandom(1, 2, 3, 4, 5, 6);
 
     public VillagerProperties()
@@ -52,7 +52,7 @@ public class VillagerProperties extends BaseLivingEntityProperties<Villager>
     {
         switch (key)
         {
-            case "villager_type" ->
+            case "villager/type" ->
             {
                 var type = typeMap.getOrDefault(value, null);
 
@@ -60,7 +60,7 @@ public class VillagerProperties extends BaseLivingEntityProperties<Villager>
                     return Pair.of(TYPE, type);
             }
 
-            case "villager_profession" ->
+            case "villager/profession" ->
             {
                 var profession = professionMap.getOrDefault(value, null);
 
@@ -68,7 +68,7 @@ public class VillagerProperties extends BaseLivingEntityProperties<Villager>
                     return Pair.of(PROFESSION, profession);
             }
 
-            case "villager_level" ->
+            case "villager/level" ->
             {
                 int level = 1;
 
@@ -115,9 +115,9 @@ public class VillagerProperties extends BaseLivingEntityProperties<Villager>
     public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
     {
         return Map.of(
-                "type", propertyHandler.get(TYPE).key().asString(),
-                "profession", propertyHandler.get(PROFESSION).key().asString(),
-                "level", propertyHandler.get(LEVEL) + ""
+                TYPE.id(), propertyHandler.get(TYPE).key().asString(),
+                PROFESSION.id(), propertyHandler.get(PROFESSION).key().asString(),
+                LEVEL.id(), propertyHandler.get(LEVEL) + ""
         );
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/VillagerProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/VillagerProperties.java
@@ -2,15 +2,19 @@ package xyz.nifeather.morph.misc.disguiseProperty.values;
 
 import it.unimi.dsi.fastutil.Pair;
 import org.bukkit.Registry;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Villager;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import xyz.nifeather.morph.misc.disguiseProperty.PropertyHandler;
 import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
+import xyz.nifeather.morph.utilities.DisguiseUtils;
 import xyz.nifeather.morph.utilities.MathUtils;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-public class VillagerProperties extends AbstractProperties
+public class VillagerProperties extends BaseLivingEntityProperties<Villager>
 {
     private final Map<String, Villager.Type> typeMap = new ConcurrentHashMap<>();
     private final Map<String, Villager.Profession> professionMap = new ConcurrentHashMap<>();
@@ -82,6 +86,38 @@ public class VillagerProperties extends AbstractProperties
             }
         }
 
-        return null;
+        return super.parseSingleInput(key, value);
+    }
+
+    @Override
+    protected @Nullable Villager tryCastEntity(@Nullable Entity targetEntity)
+    {
+        return targetEntity instanceof Villager villager ? villager : null;
+    }
+
+    @Override
+    protected void setupPropertiesFromEntity(PropertyHandler propertyHandler, @NotNull Villager targetEntity)
+    {
+        propertyHandler.set(TYPE, targetEntity.getVillagerType());
+        propertyHandler.set(PROFESSION, targetEntity.getProfession());
+        propertyHandler.set(LEVEL, targetEntity.getVillagerLevel());
+    }
+
+    @Override
+    protected void setupDefaultProperties(PropertyHandler propertyHandler)
+    {
+        propertyHandler.set(TYPE, DisguiseUtils.pick(TYPE.getRandomValues()));
+        propertyHandler.set(PROFESSION, DisguiseUtils.pick(PROFESSION.getRandomValues()));
+        propertyHandler.set(LEVEL, DisguiseUtils.pick(LEVEL.getRandomValues()));
+    }
+
+    @Override
+    public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
+    {
+        return Map.of(
+                "type", propertyHandler.get(TYPE).key().asString(),
+                "profession", propertyHandler.get(PROFESSION).key().asString(),
+                "level", propertyHandler.get(LEVEL) + ""
+        );
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/VillagerProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/VillagerProperties.java
@@ -7,6 +7,7 @@ import org.bukkit.entity.Villager;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import xyz.nifeather.morph.misc.disguiseProperty.PropertyHandler;
+import xyz.nifeather.morph.misc.disguiseProperty.PropertyNames;
 import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
 import xyz.nifeather.morph.utilities.DisguiseUtils;
 import xyz.nifeather.morph.utilities.MathUtils;
@@ -28,13 +29,13 @@ public class VillagerProperties extends BaseLivingEntityProperties<Villager>
             professionMap.put(profession.key().asString(), profession);
     }
 
-    public final SingleProperty<Villager.Type> TYPE = getSingle("villager/type", Villager.Type.PLAINS)
+    public final SingleProperty<Villager.Type> TYPE = getSingle(PropertyNames.VILLAGER_TYPE, Villager.Type.PLAINS)
             .withRandom(Registry.VILLAGER_TYPE.stream().toList());
 
-    public final SingleProperty<Villager.Profession> PROFESSION = getSingle("villager/profession", Villager.Profession.NONE)
+    public final SingleProperty<Villager.Profession> PROFESSION = getSingle(PropertyNames.VILLAGER_PROFESSION, Villager.Profession.NONE)
             .withRandom(Registry.VILLAGER_PROFESSION.stream().toList());
 
-    public final SingleProperty<Integer> LEVEL = getSingle("villager/level", 1)
+    public final SingleProperty<Integer> LEVEL = getSingle(PropertyNames.VILLAGER_LEVEL, 1)
             .withRandom(1, 2, 3, 4, 5, 6);
 
     public VillagerProperties()
@@ -52,7 +53,7 @@ public class VillagerProperties extends BaseLivingEntityProperties<Villager>
     {
         switch (key)
         {
-            case "villager/type" ->
+            case PropertyNames.VILLAGER_TYPE ->
             {
                 var type = typeMap.getOrDefault(value, null);
 
@@ -60,7 +61,7 @@ public class VillagerProperties extends BaseLivingEntityProperties<Villager>
                     return Pair.of(TYPE, type);
             }
 
-            case "villager/profession" ->
+            case PropertyNames.VILLAGER_PROFESSION ->
             {
                 var profession = professionMap.getOrDefault(value, null);
 
@@ -68,7 +69,7 @@ public class VillagerProperties extends BaseLivingEntityProperties<Villager>
                     return Pair.of(PROFESSION, profession);
             }
 
-            case "villager/level" ->
+            case PropertyNames.VILLAGER_LEVEL ->
             {
                 int level = 1;
 

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/WolfProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/WolfProperties.java
@@ -9,6 +9,7 @@ import org.bukkit.entity.Wolf.Variant;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import xyz.nifeather.morph.misc.disguiseProperty.PropertyHandler;
+import xyz.nifeather.morph.misc.disguiseProperty.PropertyNames;
 import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
 import xyz.nifeather.morph.utilities.DisguiseUtils;
 import xyz.nifeather.morph.utilities.Uuids;
@@ -27,12 +28,12 @@ public class WolfProperties extends BaseLivingEntityProperties<Wolf>
             variantMap.put(variant.key().asString(), variant);
     }
 
-    public final SingleProperty<Wolf.Variant> VARIANT = getSingle("wolf/variant", Variant.PALE)
+    public final SingleProperty<Wolf.Variant> VARIANT = getSingle(PropertyNames.WOLF_VARIANT, Variant.PALE)
             .withRandom(
                     RegistryAccess.registryAccess().getRegistry(RegistryKey.WOLF_VARIANT).stream().toList()
             );
 
-    public final SingleProperty<UUID> OWNER = getSingle("wolf/owner", Uuids.NIL_UUID);
+    public final SingleProperty<UUID> OWNER = getSingle(PropertyNames.WOLF_OWNER, Uuids.NIL_UUID);
 
     public WolfProperties()
     {
@@ -45,7 +46,7 @@ public class WolfProperties extends BaseLivingEntityProperties<Wolf>
     @Override
     protected @Nullable Pair<SingleProperty<?>, Object> parseSingleInput(String key, String value)
     {
-        if (key.equals(VARIANT.id()))
+        if (key.equals(PropertyNames.WOLF_VARIANT))
         {
             var variant = this.variantMap.getOrDefault(value, null);
 
@@ -53,7 +54,7 @@ public class WolfProperties extends BaseLivingEntityProperties<Wolf>
                 return Pair.of(VARIANT, variant);
         }
 
-        if (key.equals(OWNER.id()))
+        if (key.equals(PropertyNames.WOLF_OWNER))
         {
             UUID uuid = null;
 

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/WolfProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/WolfProperties.java
@@ -27,12 +27,12 @@ public class WolfProperties extends BaseLivingEntityProperties<Wolf>
             variantMap.put(variant.key().asString(), variant);
     }
 
-    public final SingleProperty<Wolf.Variant> VARIANT = getSingle("wolf_variant", Variant.PALE)
+    public final SingleProperty<Wolf.Variant> VARIANT = getSingle("wolf/variant", Variant.PALE)
             .withRandom(
                     RegistryAccess.registryAccess().getRegistry(RegistryKey.WOLF_VARIANT).stream().toList()
             );
 
-    public final SingleProperty<UUID> OWNER = getSingle("owner", Uuids.NIL_UUID);
+    public final SingleProperty<UUID> OWNER = getSingle("wolf/owner", Uuids.NIL_UUID);
 
     public WolfProperties()
     {
@@ -94,7 +94,7 @@ public class WolfProperties extends BaseLivingEntityProperties<Wolf>
     public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
     {
         return Map.of(
-                "variant", propertyHandler.get(VARIANT).key().asString()
+                VARIANT.id(), propertyHandler.get(VARIANT).key().asString()
         );
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/WolfProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/WolfProperties.java
@@ -3,15 +3,21 @@ package xyz.nifeather.morph.misc.disguiseProperty.values;
 import io.papermc.paper.registry.RegistryAccess;
 import io.papermc.paper.registry.RegistryKey;
 import it.unimi.dsi.fastutil.Pair;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Wolf;
 import org.bukkit.entity.Wolf.Variant;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import xyz.nifeather.morph.misc.disguiseProperty.PropertyHandler;
 import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
+import xyz.nifeather.morph.utilities.DisguiseUtils;
+import xyz.nifeather.morph.utilities.Uuids;
 
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
-public class WolfProperties extends AbstractProperties
+public class WolfProperties extends BaseLivingEntityProperties<Wolf>
 {
     private final Map<String, Wolf.Variant> variantMap = new ConcurrentHashMap<>();
 
@@ -26,12 +32,14 @@ public class WolfProperties extends AbstractProperties
                     RegistryAccess.registryAccess().getRegistry(RegistryKey.WOLF_VARIANT).stream().toList()
             );
 
+    public final SingleProperty<UUID> OWNER = getSingle("owner", Uuids.NIL_UUID);
+
     public WolfProperties()
     {
         initMap();
         VARIANT.withValidInput(variantMap.keySet());
 
-        registerSingle(VARIANT);
+        registerSingle(VARIANT, OWNER);
     }
 
     @Override
@@ -45,6 +53,48 @@ public class WolfProperties extends AbstractProperties
                 return Pair.of(VARIANT, variant);
         }
 
-        return null;
+        if (key.equals(OWNER.id()))
+        {
+            UUID uuid = null;
+
+            try
+            {
+                uuid = UUID.fromString(value);
+                return Pair.of(OWNER, uuid);
+            }
+            catch (Throwable ignored)
+            {
+            }
+
+            return null;
+        }
+
+        return super.parseSingleInput(key, value);
+    }
+
+    @Override
+    protected @Nullable Wolf tryCastEntity(@Nullable Entity targetEntity)
+    {
+        return targetEntity instanceof Wolf wolf ? wolf : null;
+    }
+
+    @Override
+    protected void setupPropertiesFromEntity(PropertyHandler propertyHandler, @NotNull Wolf targetEntity)
+    {
+        propertyHandler.set(VARIANT, targetEntity.getVariant());
+    }
+
+    @Override
+    protected void setupDefaultProperties(PropertyHandler propertyHandler)
+    {
+        propertyHandler.set(VARIANT, DisguiseUtils.pick(VARIANT.getRandomValues()));
+    }
+
+    @Override
+    public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
+    {
+        return Map.of(
+                "variant", propertyHandler.get(VARIANT).key().asString()
+        );
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/WolfProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/WolfProperties.java
@@ -91,10 +91,9 @@ public class WolfProperties extends BaseLivingEntityProperties<Wolf>
     }
 
     @Override
-    public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
+    protected void appendNetworkMap(PropertyHandler propertyHandler, Map<String, String> map)
     {
-        return Map.of(
-                VARIANT.id(), propertyHandler.get(VARIANT).key().asString()
-        );
+        super.appendNetworkMap(propertyHandler, map);
+        map.put(VARIANT.id(), propertyHandler.get(VARIANT).key().asString());
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/ZoglinProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/ZoglinProperties.java
@@ -7,13 +7,14 @@ import org.bukkit.entity.Zoglin;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import xyz.nifeather.morph.misc.disguiseProperty.PropertyHandler;
+import xyz.nifeather.morph.misc.disguiseProperty.PropertyNames;
 import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
 
 import java.util.Map;
 
 public class ZoglinProperties extends BaseLivingEntityProperties<Zoglin>
 {
-    public final SingleProperty<Boolean> IS_BABY = getSingle("zoglin/is_baby", false);
+    public final SingleProperty<Boolean> IS_BABY = getSingle(PropertyNames.ZOGLIN_IS_BABY, false);
 
     public ZoglinProperties()
     {
@@ -29,7 +30,7 @@ public class ZoglinProperties extends BaseLivingEntityProperties<Zoglin>
     @Override
     protected @Nullable Pair<SingleProperty<?>, Object> parseSingleInput(String key, String value)
     {
-        if (key.equals(IS_BABY.id()))
+        if (key.equals(PropertyNames.ZOGLIN_IS_BABY))
             return Pair.of(IS_BABY, Boolean.valueOf(value));
 
         return super.parseSingleInput(key, value);

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/ZoglinProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/ZoglinProperties.java
@@ -47,10 +47,9 @@ public class ZoglinProperties extends BaseLivingEntityProperties<Zoglin>
     }
 
     @Override
-    public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
+    protected void appendNetworkMap(PropertyHandler propertyHandler, Map<String, String> map)
     {
-        return Map.of(
-                IS_BABY.id(), propertyHandler.get(IS_BABY).toString().toLowerCase()
-        );
+        super.appendNetworkMap(propertyHandler, map);
+        map.put(IS_BABY.id(), propertyHandler.get(IS_BABY).toString().toLowerCase());
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/ZoglinProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/ZoglinProperties.java
@@ -1,0 +1,56 @@
+package xyz.nifeather.morph.misc.disguiseProperty.values;
+
+import it.unimi.dsi.fastutil.Pair;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Hoglin;
+import org.bukkit.entity.Zoglin;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import xyz.nifeather.morph.misc.disguiseProperty.PropertyHandler;
+import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
+
+import java.util.Map;
+
+public class ZoglinProperties extends BaseLivingEntityProperties<Zoglin>
+{
+    public final SingleProperty<Boolean> IS_BABY = getSingle("is_baby", false);
+
+    public ZoglinProperties()
+    {
+        registerSingle(IS_BABY);
+    }
+
+    @Override
+    protected @Nullable Zoglin tryCastEntity(@Nullable Entity targetEntity)
+    {
+        return targetEntity instanceof Zoglin hoglin ? hoglin : null;
+    }
+
+    @Override
+    protected @Nullable Pair<SingleProperty<?>, Object> parseSingleInput(String key, String value)
+    {
+        if (key.equals(IS_BABY.id()))
+            return Pair.of(IS_BABY, Boolean.valueOf(value));
+
+        return super.parseSingleInput(key, value);
+    }
+
+    @Override
+    protected void setupPropertiesFromEntity(PropertyHandler propertyHandler, @NotNull Zoglin targetEntity)
+    {
+        propertyHandler.set(IS_BABY, !targetEntity.isAdult());
+    }
+
+    @Override
+    protected void setupDefaultProperties(PropertyHandler propertyHandler)
+    {
+    }
+
+    @Override
+    public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
+    {
+        return Map.of(
+                "is_baby", propertyHandler.get(IS_BABY).toString().toLowerCase()
+        );
+    }
+}

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/ZoglinProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/ZoglinProperties.java
@@ -13,7 +13,7 @@ import java.util.Map;
 
 public class ZoglinProperties extends BaseLivingEntityProperties<Zoglin>
 {
-    public final SingleProperty<Boolean> IS_BABY = getSingle("is_baby", false);
+    public final SingleProperty<Boolean> IS_BABY = getSingle("zoglin/is_baby", false);
 
     public ZoglinProperties()
     {
@@ -50,7 +50,7 @@ public class ZoglinProperties extends BaseLivingEntityProperties<Zoglin>
     public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
     {
         return Map.of(
-                "is_baby", propertyHandler.get(IS_BABY).toString().toLowerCase()
+                IS_BABY.id(), propertyHandler.get(IS_BABY).toString().toLowerCase()
         );
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/ZombieProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/ZombieProperties.java
@@ -13,7 +13,7 @@ import java.util.Map;
 
 public class ZombieProperties extends BaseLivingEntityProperties<Zombie>
 {
-    public final SingleProperty<Boolean> IS_BABY = getSingle("is_baby", false);
+    public final SingleProperty<Boolean> IS_BABY = getSingle("zombie/is_baby", false);
 
     public ZombieProperties()
     {
@@ -50,7 +50,7 @@ public class ZombieProperties extends BaseLivingEntityProperties<Zombie>
     public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
     {
         return Map.of(
-                "is_baby", propertyHandler.get(IS_BABY).toString().toLowerCase()
+                IS_BABY.id(), propertyHandler.get(IS_BABY).toString().toLowerCase()
         );
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/ZombieProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/ZombieProperties.java
@@ -47,10 +47,9 @@ public class ZombieProperties extends BaseLivingEntityProperties<Zombie>
     }
 
     @Override
-    public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
+    protected void appendNetworkMap(PropertyHandler propertyHandler, Map<String, String> map)
     {
-        return Map.of(
-                IS_BABY.id(), propertyHandler.get(IS_BABY).toString().toLowerCase()
-        );
+        super.appendNetworkMap(propertyHandler, map);
+        map.put(IS_BABY.id(), propertyHandler.get(IS_BABY).toString().toLowerCase());
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/ZombieProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/ZombieProperties.java
@@ -1,0 +1,56 @@
+package xyz.nifeather.morph.misc.disguiseProperty.values;
+
+import it.unimi.dsi.fastutil.Pair;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Zoglin;
+import org.bukkit.entity.Zombie;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import xyz.nifeather.morph.misc.disguiseProperty.PropertyHandler;
+import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
+
+import java.util.Map;
+
+public class ZombieProperties extends BaseLivingEntityProperties<Zombie>
+{
+    public final SingleProperty<Boolean> IS_BABY = getSingle("is_baby", false);
+
+    public ZombieProperties()
+    {
+        registerSingle(IS_BABY);
+    }
+
+    @Override
+    protected @Nullable Zombie tryCastEntity(@Nullable Entity targetEntity)
+    {
+        return targetEntity instanceof Zombie zombie ? zombie : null;
+    }
+
+    @Override
+    protected @Nullable Pair<SingleProperty<?>, Object> parseSingleInput(String key, String value)
+    {
+        if (key.equals(IS_BABY.id()))
+            return Pair.of(IS_BABY, Boolean.valueOf(value));
+
+        return super.parseSingleInput(key, value);
+    }
+
+    @Override
+    protected void setupPropertiesFromEntity(PropertyHandler propertyHandler, @NotNull Zombie targetEntity)
+    {
+        propertyHandler.set(IS_BABY, !targetEntity.isAdult());
+    }
+
+    @Override
+    protected void setupDefaultProperties(PropertyHandler propertyHandler)
+    {
+    }
+
+    @Override
+    public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
+    {
+        return Map.of(
+                "is_baby", propertyHandler.get(IS_BABY).toString().toLowerCase()
+        );
+    }
+}

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/ZombieProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/ZombieProperties.java
@@ -7,13 +7,14 @@ import org.bukkit.entity.Zombie;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import xyz.nifeather.morph.misc.disguiseProperty.PropertyHandler;
+import xyz.nifeather.morph.misc.disguiseProperty.PropertyNames;
 import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
 
 import java.util.Map;
 
 public class ZombieProperties extends BaseLivingEntityProperties<Zombie>
 {
-    public final SingleProperty<Boolean> IS_BABY = getSingle("zombie/is_baby", false);
+    public final SingleProperty<Boolean> IS_BABY = getSingle(PropertyNames.ZOMBIE_IS_BABY, false);
 
     public ZombieProperties()
     {
@@ -29,7 +30,7 @@ public class ZombieProperties extends BaseLivingEntityProperties<Zombie>
     @Override
     protected @Nullable Pair<SingleProperty<?>, Object> parseSingleInput(String key, String value)
     {
-        if (key.equals(IS_BABY.id()))
+        if (key.equals(PropertyNames.ZOMBIE_IS_BABY))
             return Pair.of(IS_BABY, Boolean.valueOf(value));
 
         return super.parseSingleInput(key, value);

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/ZombieVillagerProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/ZombieVillagerProperties.java
@@ -8,6 +8,7 @@ import org.bukkit.entity.ZombieVillager;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import xyz.nifeather.morph.misc.disguiseProperty.PropertyHandler;
+import xyz.nifeather.morph.misc.disguiseProperty.PropertyNames;
 import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
 import xyz.nifeather.morph.utilities.DisguiseUtils;
 import xyz.nifeather.morph.utilities.MathUtils;
@@ -29,16 +30,16 @@ public class ZombieVillagerProperties extends BaseLivingEntityProperties<ZombieV
             professionMap.put(profession.key().asString(), profession);
     }
 
-    public final SingleProperty<Villager.Type> TYPE = getSingle("zombie_villager/type", Villager.Type.PLAINS)
+    public final SingleProperty<Villager.Type> TYPE = getSingle(PropertyNames.ZOMBIE_VILLAGER_TYPE, Villager.Type.PLAINS)
             .withRandom(Registry.VILLAGER_TYPE.stream().toList());
 
-    public final SingleProperty<Villager.Profession> PROFESSION = getSingle("zombie_villager/profession", Villager.Profession.NONE)
+    public final SingleProperty<Villager.Profession> PROFESSION = getSingle(PropertyNames.ZOMBIE_VILLAGER_PROFESSION, Villager.Profession.NONE)
             .withRandom(Registry.VILLAGER_PROFESSION.stream().toList());
 
-    public final SingleProperty<Integer> LEVEL = getSingle("zombie_villager/level", 1)
+    public final SingleProperty<Integer> LEVEL = getSingle(PropertyNames.ZOMBIE_VILLAGER_LEVEL, 1)
             .withRandom(1, 2, 3, 4, 5, 6);
 
-    public final SingleProperty<Boolean> IS_BABY = getSingle("zombie_villager/is_baby", false);
+    public final SingleProperty<Boolean> IS_BABY = getSingle(PropertyNames.ZOMBIE_VILLAGER_IS_BABY, false);
 
     public ZombieVillagerProperties()
     {
@@ -54,7 +55,7 @@ public class ZombieVillagerProperties extends BaseLivingEntityProperties<ZombieV
     {
         switch (key)
         {
-            case "zombie_villager/type" ->
+            case PropertyNames.ZOMBIE_VILLAGER_TYPE ->
             {
                 var type = typeMap.getOrDefault(value, null);
 
@@ -62,7 +63,7 @@ public class ZombieVillagerProperties extends BaseLivingEntityProperties<ZombieV
                     return Pair.of(TYPE, type);
             }
 
-            case "zombie_villager/profession" ->
+            case PropertyNames.ZOMBIE_VILLAGER_PROFESSION ->
             {
                 var profession = professionMap.getOrDefault(value, null);
 
@@ -70,12 +71,12 @@ public class ZombieVillagerProperties extends BaseLivingEntityProperties<ZombieV
                     return Pair.of(PROFESSION, profession);
             }
 
-            case "zombie_villager/is_baby" ->
+            case PropertyNames.ZOMBIE_VILLAGER_IS_BABY ->
             {
                 return Pair.of(IS_BABY, Boolean.valueOf(value));
             }
 
-            case "zombie_villager/level" ->
+            case PropertyNames.ZOMBIE_VILLAGER_LEVEL ->
             {
                 return Pair.of(LEVEL, MathUtils.clamp(1, 6, MathUtils.parseIntOr(value, 1)));
             }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/ZombieVillagerProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/ZombieVillagerProperties.java
@@ -28,13 +28,13 @@ public class ZombieVillagerProperties extends BaseLivingEntityProperties<ZombieV
             professionMap.put(profession.key().asString(), profession);
     }
 
-    public final SingleProperty<Villager.Type> TYPE = getSingle("villager_type", Villager.Type.PLAINS)
+    public final SingleProperty<Villager.Type> TYPE = getSingle("zombie_villager/type", Villager.Type.PLAINS)
             .withRandom(Registry.VILLAGER_TYPE.stream().toList());
 
-    public final SingleProperty<Villager.Profession> PROFESSION = getSingle("villager_profession", Villager.Profession.NONE)
+    public final SingleProperty<Villager.Profession> PROFESSION = getSingle("zombie_villager/profession", Villager.Profession.NONE)
             .withRandom(Registry.VILLAGER_PROFESSION.stream().toList());
 
-    public final SingleProperty<Boolean> IS_BABY = getSingle("is_baby", false);
+    public final SingleProperty<Boolean> IS_BABY = getSingle("zombie_villager/is_baby", false);
 
     public ZombieVillagerProperties()
     {
@@ -50,7 +50,7 @@ public class ZombieVillagerProperties extends BaseLivingEntityProperties<ZombieV
     {
         switch (key)
         {
-            case "villager_type" ->
+            case "zombie_villager/type" ->
             {
                 var type = typeMap.getOrDefault(value, null);
 
@@ -58,7 +58,7 @@ public class ZombieVillagerProperties extends BaseLivingEntityProperties<ZombieV
                     return Pair.of(TYPE, type);
             }
 
-            case "villager_profession" ->
+            case "zombie_villager/profession" ->
             {
                 var profession = professionMap.getOrDefault(value, null);
 
@@ -66,7 +66,7 @@ public class ZombieVillagerProperties extends BaseLivingEntityProperties<ZombieV
                     return Pair.of(PROFESSION, profession);
             }
 
-            case "is_baby" ->
+            case "zombie_villager/is_baby" ->
             {
                 return Pair.of(IS_BABY, Boolean.valueOf(value));
             }
@@ -99,8 +99,8 @@ public class ZombieVillagerProperties extends BaseLivingEntityProperties<ZombieV
     public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
     {
         return Map.of(
-                "type", propertyHandler.get(TYPE).key().asString(),
-                "profession", propertyHandler.get(PROFESSION).key().asString()
+                TYPE.id(), propertyHandler.get(TYPE).key().asString(),
+                PROFESSION.id(), propertyHandler.get(PROFESSION).key().asString()
         );
     }
 }

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/ZombieVillagerProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/ZombieVillagerProperties.java
@@ -10,6 +10,7 @@ import org.jetbrains.annotations.Nullable;
 import xyz.nifeather.morph.misc.disguiseProperty.PropertyHandler;
 import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
 import xyz.nifeather.morph.utilities.DisguiseUtils;
+import xyz.nifeather.morph.utilities.MathUtils;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -34,6 +35,9 @@ public class ZombieVillagerProperties extends BaseLivingEntityProperties<ZombieV
     public final SingleProperty<Villager.Profession> PROFESSION = getSingle("zombie_villager/profession", Villager.Profession.NONE)
             .withRandom(Registry.VILLAGER_PROFESSION.stream().toList());
 
+    public final SingleProperty<Integer> LEVEL = getSingle("zombie_villager/level", 0)
+            .withRandom(1, 2, 3, 4, 5, 6);
+
     public final SingleProperty<Boolean> IS_BABY = getSingle("zombie_villager/is_baby", false);
 
     public ZombieVillagerProperties()
@@ -42,7 +46,7 @@ public class ZombieVillagerProperties extends BaseLivingEntityProperties<ZombieV
         TYPE.withValidInput(typeMap.keySet());
         PROFESSION.withValidInput(professionMap.keySet());
 
-        registerSingle(TYPE, PROFESSION, IS_BABY);
+        registerSingle(TYPE, PROFESSION, IS_BABY, LEVEL);
     }
 
     @Override
@@ -69,6 +73,11 @@ public class ZombieVillagerProperties extends BaseLivingEntityProperties<ZombieV
             case "zombie_villager/is_baby" ->
             {
                 return Pair.of(IS_BABY, Boolean.valueOf(value));
+            }
+
+            case "zombie_villager/level" ->
+            {
+                return Pair.of(LEVEL, MathUtils.clamp(1, 6, MathUtils.parseIntOr(value, 1)));
             }
         }
 

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/ZombieVillagerProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/ZombieVillagerProperties.java
@@ -1,0 +1,106 @@
+package xyz.nifeather.morph.misc.disguiseProperty.values;
+
+import it.unimi.dsi.fastutil.Pair;
+import org.bukkit.Registry;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Villager;
+import org.bukkit.entity.ZombieVillager;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import xyz.nifeather.morph.misc.disguiseProperty.PropertyHandler;
+import xyz.nifeather.morph.misc.disguiseProperty.SingleProperty;
+import xyz.nifeather.morph.utilities.DisguiseUtils;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class ZombieVillagerProperties extends BaseLivingEntityProperties<ZombieVillager>
+{
+    private final Map<String, Villager.Type> typeMap = new ConcurrentHashMap<>();
+    private final Map<String, Villager.Profession> professionMap = new ConcurrentHashMap<>();
+
+    private void initMaps()
+    {
+        for (var type : Registry.VILLAGER_TYPE)
+            typeMap.put(type.key().asString(), type);
+
+        for (var profession : Registry.VILLAGER_PROFESSION)
+            professionMap.put(profession.key().asString(), profession);
+    }
+
+    public final SingleProperty<Villager.Type> TYPE = getSingle("villager_type", Villager.Type.PLAINS)
+            .withRandom(Registry.VILLAGER_TYPE.stream().toList());
+
+    public final SingleProperty<Villager.Profession> PROFESSION = getSingle("villager_profession", Villager.Profession.NONE)
+            .withRandom(Registry.VILLAGER_PROFESSION.stream().toList());
+
+    public final SingleProperty<Boolean> IS_BABY = getSingle("is_baby", false);
+
+    public ZombieVillagerProperties()
+    {
+        initMaps();
+        TYPE.withValidInput(typeMap.keySet());
+        PROFESSION.withValidInput(professionMap.keySet());
+
+        registerSingle(TYPE, PROFESSION, IS_BABY);
+    }
+
+    @Override
+    protected @Nullable Pair<SingleProperty<?>, Object> parseSingleInput(String key, String value)
+    {
+        switch (key)
+        {
+            case "villager_type" ->
+            {
+                var type = typeMap.getOrDefault(value, null);
+
+                if (type != null)
+                    return Pair.of(TYPE, type);
+            }
+
+            case "villager_profession" ->
+            {
+                var profession = professionMap.getOrDefault(value, null);
+
+                if (profession != null)
+                    return Pair.of(PROFESSION, profession);
+            }
+
+            case "is_baby" ->
+            {
+                return Pair.of(IS_BABY, Boolean.valueOf(value));
+            }
+        }
+
+        return super.parseSingleInput(key, value);
+    }
+
+    @Override
+    protected @Nullable ZombieVillager tryCastEntity(@Nullable Entity targetEntity)
+    {
+        return targetEntity instanceof ZombieVillager villager ? villager : null;
+    }
+
+    @Override
+    protected void setupPropertiesFromEntity(PropertyHandler propertyHandler, @NotNull ZombieVillager targetEntity)
+    {
+        propertyHandler.set(TYPE, targetEntity.getVillagerType());
+        propertyHandler.set(PROFESSION, targetEntity.getVillagerProfession());
+    }
+
+    @Override
+    protected void setupDefaultProperties(PropertyHandler propertyHandler)
+    {
+        propertyHandler.set(TYPE, DisguiseUtils.pick(TYPE.getRandomValues()));
+        propertyHandler.set(PROFESSION, DisguiseUtils.pick(PROFESSION.getRandomValues()));
+    }
+
+    @Override
+    public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
+    {
+        return Map.of(
+                "type", propertyHandler.get(TYPE).key().asString(),
+                "profession", propertyHandler.get(PROFESSION).key().asString()
+        );
+    }
+}

--- a/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/ZombieVillagerProperties.java
+++ b/src/main/java/xyz/nifeather/morph/misc/disguiseProperty/values/ZombieVillagerProperties.java
@@ -35,7 +35,7 @@ public class ZombieVillagerProperties extends BaseLivingEntityProperties<ZombieV
     public final SingleProperty<Villager.Profession> PROFESSION = getSingle("zombie_villager/profession", Villager.Profession.NONE)
             .withRandom(Registry.VILLAGER_PROFESSION.stream().toList());
 
-    public final SingleProperty<Integer> LEVEL = getSingle("zombie_villager/level", 0)
+    public final SingleProperty<Integer> LEVEL = getSingle("zombie_villager/level", 1)
             .withRandom(1, 2, 3, 4, 5, 6);
 
     public final SingleProperty<Boolean> IS_BABY = getSingle("zombie_villager/is_baby", false);
@@ -105,11 +105,12 @@ public class ZombieVillagerProperties extends BaseLivingEntityProperties<ZombieV
     }
 
     @Override
-    public Map<String, String> mapToNetworkProperties(PropertyHandler propertyHandler)
+    protected void appendNetworkMap(PropertyHandler propertyHandler, Map<String, String> map)
     {
-        return Map.of(
-                TYPE.id(), propertyHandler.get(TYPE).key().asString(),
-                PROFESSION.id(), propertyHandler.get(PROFESSION).key().asString()
-        );
+        super.appendNetworkMap(propertyHandler, map);
+
+        map.put(TYPE.id(), propertyHandler.get(TYPE).key().asString());
+        map.put(PROFESSION.id(), propertyHandler.get(PROFESSION).key().asString());
+        map.put(LEVEL.id(), propertyHandler.get(LEVEL).toString());
     }
 }

--- a/src/main/java/xyz/nifeather/morph/network/server/MorphClientHandler.java
+++ b/src/main/java/xyz/nifeather/morph/network/server/MorphClientHandler.java
@@ -374,6 +374,7 @@ public class MorphClientHandler extends MorphPluginObject implements BasicClient
         session.clientFeatures.addAll(clientInitializeRecord.clientFeatures());
         session.options.clientApiVersion = clientInitializeRecord.apiVersion();
         session.initializeState = InitializeState.API_CHECKED;
+        session.apiVersion = clientVersion;
 
         commandPacketHandler.sendInitializeRespond(player, this.getInitializeRespond());
     }

--- a/src/main/java/xyz/nifeather/morph/network/server/PlayerSession.java
+++ b/src/main/java/xyz/nifeather/morph/network/server/PlayerSession.java
@@ -11,6 +11,8 @@ import java.util.concurrent.CopyOnWriteArrayList;
 
 public class PlayerSession
 {
+    public volatile int apiVersion;
+
     public PlayerSession(Player bindingPlayer, List<String> clientFeatures)
     {
         options = new PlayerOptions<>(bindingPlayer);
@@ -20,10 +22,10 @@ public class PlayerSession
     public final PlayerOptions<Player> options;
 
     @NotNull
-    public InitializeState initializeState = InitializeState.NOT_CONNECTED;
+    public volatile InitializeState initializeState = InitializeState.NOT_CONNECTED;
 
     @NotNull
-    public ConnectionState connectionState = ConnectionState.NOT_CONNECTED;
+    public volatile ConnectionState connectionState = ConnectionState.NOT_CONNECTED;
 
     public final List<String> clientFeatures = new CopyOnWriteArrayList<>();
 

--- a/src/main/java/xyz/nifeather/morph/providers/disguise/DefaultDisguiseProvider.java
+++ b/src/main/java/xyz/nifeather/morph/providers/disguise/DefaultDisguiseProvider.java
@@ -238,7 +238,7 @@ public abstract class DefaultDisguiseProvider extends DisguiseProvider
     }
 
     @Override
-    public void onPostConstructDisguise(DisguiseState state, @Nullable Entity targetEntity)
+    public void postBuildDisguise(DisguiseState state, @Nullable Entity targetEntity)
     {
         //被动技能
         var abilities = abilityHandler.getAbilitiesFor(state.skillLookupIdentifier());

--- a/src/main/java/xyz/nifeather/morph/providers/disguise/DisguiseProvider.java
+++ b/src/main/java/xyz/nifeather/morph/providers/disguise/DisguiseProvider.java
@@ -115,16 +115,6 @@ public abstract class DisguiseProvider extends MorphPluginObject
     public abstract DisguiseBackend<?, ?> getPreferredBackend();
 
     /**
-     * Resets a player's some attributes from a disguise but not un-disguising them.
-     * Used for keeping disguise appearance while switching (if this provider allow switching to that disguise without un-disguise)
-     *
-     * @param state The {@link DisguiseState} to reset
-     */
-    public void resetDisguise(DisguiseState state)
-    {
-    }
-
-    /**
      * 取消某个玩家的伪装
      * @param player 目标玩家
      * @return 操作是否成功
@@ -143,56 +133,6 @@ public abstract class DisguiseProvider extends MorphPluginObject
     }
 
     /**
-     * 从某一实体构建伪装
-     *
-     * @param info 伪装信息
-     * @param target 目标实体
-     * @return 一个包含伪装Wrapper的 {@link DisguiseResult}, 失败时返回 {@link DisguiseResult#FAIL}
-     */
-    @NotNull
-    protected DisguiseResult constructFromEntity(DisguiseMeta info, @Nullable Entity target)
-    {
-        if (target == null) return DisguiseResult.fail();
-
-        boolean allowClone = false;
-
-        var backend = getPreferredBackend();
-
-        DisguiseWrapper<?> ourDisguise;
-        DisguiseState theirState = morphs.getDisguiseStateFor(target);
-        DisguiseWrapper<?> theirDisguise = theirState != null ? theirState.getDisguiseWrapper() : null;
-
-        if (theirState != null)
-        {
-            var key = theirState.getDisguiseIdentifier();
-
-            //ID不一样则返回失败
-            if (!key.equals(info.getIdentifier())) return DisguiseResult.fail();
-
-            allowClone = canCloneDisguise(info, target, theirState, theirDisguise);
-        }
-
-        ourDisguise = allowClone
-                ? theirDisguise.clone()
-                : canConstruct(info, target, theirState) ? backend.createInstance(target) : null;
-
-        return ourDisguise == null
-                ? DisguiseResult.fail()
-                : DisguiseResult.success(ourDisguise);
-    }
-
-    /**
-     * 我们是否可以根据给定的实体构建伪装？
-     *
-     * @param info {@link DisguiseMeta}
-     * @param targetEntity 目标实体
-     * @param theirState 他们的{@link DisguiseState}，为null则代表他们不是玩家或没有通过MorphPlugin伪装
-     * @return 是否允许此操作，如果theirState不为null则优先检查theirState是否和传入的info相匹配
-     */
-    public abstract boolean canConstruct(DisguiseMeta info, Entity targetEntity,
-                                         @Nullable DisguiseState theirState);
-
-    /**
      * 我们是否可以克隆目标实体/玩家的伪装？
      *
      * @param info {@link DisguiseMeta}
@@ -203,23 +143,11 @@ public abstract class DisguiseProvider extends MorphPluginObject
     public abstract boolean canCloneEquipment(DisguiseMeta info, Entity targetEntity, DisguiseState theirState);
 
     /**
-     * 是否可以克隆某个实体现有的伪装?
-     *
-     * @param info {@link DisguiseMeta}
-     * @param targetEntity 目标实体
-     * @param theirDisguise 他们目前应用的伪装
-     * @param theirState 他们的{@link DisguiseState}，为null则代表他们不是玩家或没有通过MorphPlugin伪装
-     * @return 是否允许此操作
-     */
-    protected abstract boolean canCloneDisguise(DisguiseMeta info, Entity targetEntity,
-                                                @NotNull DisguiseState theirState, @NotNull DisguiseWrapper<?> theirDisguise);
-
-    /**
      * 伪装后要做的事
      * @param state {@link DisguiseState}
      * @param targetEntity 目标实体
      */
-    public void onPostConstructDisguise(DisguiseState state, @Nullable Entity targetEntity)
+    public void postBuildDisguise(DisguiseState state, @Nullable Entity targetEntity)
     {
     }
 

--- a/src/main/java/xyz/nifeather/morph/providers/disguise/DisguiseProvider.java
+++ b/src/main/java/xyz/nifeather/morph/providers/disguise/DisguiseProvider.java
@@ -1,30 +1,22 @@
 package xyz.nifeather.morph.providers.disguise;
 
-import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import net.kyori.adventure.text.Component;
-import net.minecraft.nbt.CompoundTag;
-import org.bukkit.craftbukkit.entity.CraftLivingEntity;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import xiamomc.pluginbase.Annotations.Initializer;
 import xiamomc.pluginbase.Annotations.Resolved;
-import xiamomc.pluginbase.Bindables.BindableList;
 import xyz.nifeather.morph.MorphManager;
 import xyz.nifeather.morph.MorphPluginObject;
 import xyz.nifeather.morph.backends.DisguiseBackend;
 import xyz.nifeather.morph.backends.DisguiseWrapper;
-import xyz.nifeather.morph.config.ConfigOption;
-import xyz.nifeather.morph.config.MorphConfigManager;
 import xyz.nifeather.morph.misc.DisguiseMeta;
 import xyz.nifeather.morph.misc.DisguiseState;
+import xyz.nifeather.morph.misc.disguiseProperty.DisguiseProperties;
 import xyz.nifeather.morph.network.commands.S2C.AbstractS2CCommand;
 import xyz.nifeather.morph.providers.animation.AnimationProvider;
-import xyz.nifeather.morph.utilities.NbtUtils;
 
 import java.util.List;
-import java.util.regex.Pattern;
 
 /**
  * 负责提供伪装及其相关功能的组件。
@@ -87,6 +79,8 @@ public abstract class DisguiseProvider extends MorphPluginObject
      */
     public void setupProperties(DisguiseState state, @Nullable Entity targetEntity)
     {
+        var matchingProperty = DisguiseProperties.INSTANCE.get(state.getEntityType());
+        matchingProperty.setupProperties(state, targetEntity);
     }
 
     /**
@@ -110,66 +104,6 @@ public abstract class DisguiseProvider extends MorphPluginObject
     public boolean validForClient(DisguiseState state)
     {
         return false;
-    }
-
-    /**
-     * 获取此伪装的初始NBT（如果有），如果有目标实体则尝试复制目标实体的NBT
-     * @param state
-     * @param targetEntity
-     * @param enableCulling 是否要隐藏一些信息防止被客户端获取？
-     * @return
-     */
-    @Nullable
-    public CompoundTag getInitialNbtCompound(DisguiseState state, @Nullable Entity targetEntity, boolean enableCulling)
-    {
-        if (targetEntity instanceof CraftLivingEntity
-            && canConstruct(getMorphManager().getDisguiseMeta(state.getDisguiseIdentifier()), targetEntity, null))
-        {
-            var rawCompound = NbtUtils.getRawTagCompound(targetEntity);
-
-            return enableCulling ? cullNBT(rawCompound) : rawCompound;
-        }
-
-        return null;
-    }
-
-    private static final BindableList<String> blackListTags = new BindableList<>();
-    private static final BindableList<String> blackListPatterns = new BindableList<>();
-    private static boolean bindableInitialized;
-
-    @Initializer
-    private void load(MorphConfigManager configManager)
-    {
-        if (!bindableInitialized)
-        {
-            configManager.bind(String.class, blackListTags, ConfigOption.BLACKLIST_TAGS);
-            configManager.bind(String.class, blackListPatterns, ConfigOption.BLACKLIST_PATTERNS);
-
-            bindableInitialized = true;
-        }
-    }
-
-    public static CompoundTag cullNBT(CompoundTag compound)
-    {
-        if (compound == null) return null;
-
-        //compound.r() -> NBTCompound#remove()
-
-        blackListTags.forEach(compound::remove);
-
-        var toRemove = new ObjectArrayList<String>();
-
-        blackListPatterns.forEach(pattern ->
-        {
-            compound.forEach((id, tag) ->
-            {
-                if (Pattern.matches(pattern, id))
-                    toRemove.add(id);
-            });
-        });
-
-        toRemove.forEach(compound::remove);
-        return compound;
     }
 
     /**
@@ -244,7 +178,7 @@ public abstract class DisguiseProvider extends MorphPluginObject
 
         return ourDisguise == null
                 ? DisguiseResult.fail()
-                : DisguiseResult.success(ourDisguise, true);
+                : DisguiseResult.success(ourDisguise);
     }
 
     /**

--- a/src/main/java/xyz/nifeather/morph/providers/disguise/DisguiseResult.java
+++ b/src/main/java/xyz/nifeather/morph/providers/disguise/DisguiseResult.java
@@ -6,25 +6,19 @@ import xyz.nifeather.morph.backends.DisguiseWrapper;
 /**
  * @param wrapperInstance Wrapper实例，在失败时为空
  * @param success 操作是否成功
- * @param isCopy 此伪装是否克隆自其他实体或其他玩家的伪装
  */
-public record DisguiseResult(@Nullable DisguiseWrapper<?> wrapperInstance, boolean success, boolean isCopy, boolean failSilent)
+public record DisguiseResult(@Nullable DisguiseWrapper<?> wrapperInstance, boolean success, boolean failSilent)
 {
-    public static final DisguiseResult FAIL = new DisguiseResult(null, false, false, false);
-    public static final DisguiseResult FAIL_SILENT = new DisguiseResult(null, false, false, true);
+    public static final DisguiseResult FAIL = new DisguiseResult(null, false, false);
+    public static final DisguiseResult FAIL_SILENT = new DisguiseResult(null, false, true);
 
     public static DisguiseResult fail()
     {
         return DisguiseResult.FAIL;
     }
 
-    public static DisguiseResult success(DisguiseWrapper<?> disguise, boolean isCopy)
-    {
-        return new DisguiseResult(disguise, true, isCopy, false);
-    }
-
     public static DisguiseResult success(DisguiseWrapper<?> disguise)
     {
-        return new DisguiseResult(disguise, true, false, false);
+        return new DisguiseResult(disguise, true, false);
     }
 }

--- a/src/main/java/xyz/nifeather/morph/providers/disguise/FallbackDisguiseProvider.java
+++ b/src/main/java/xyz/nifeather/morph/providers/disguise/FallbackDisguiseProvider.java
@@ -50,8 +50,7 @@ public class FallbackDisguiseProvider extends DefaultDisguiseProvider
         return DisguiseResult.fail();
     }
 
-    @Override
-    public boolean canConstruct(DisguiseMeta info, Entity targetEntity, @Nullable DisguiseState theirState)
+    private boolean canConstruct(DisguiseMeta info, Entity targetEntity, @Nullable DisguiseState theirState)
     {
         return false;
     }
@@ -66,12 +65,6 @@ public class FallbackDisguiseProvider extends DefaultDisguiseProvider
      */
     @Override
     public boolean canCloneEquipment(DisguiseMeta info, Entity targetEntity, DisguiseState theirState)
-    {
-        return false;
-    }
-
-    @Override
-    protected boolean canCloneDisguise(DisguiseMeta info, Entity targetEntity, @NotNull DisguiseState theirState, @NotNull DisguiseWrapper<?> theirDisguise)
     {
         return false;
     }

--- a/src/main/java/xyz/nifeather/morph/providers/disguise/PlayerDisguiseProvider.java
+++ b/src/main/java/xyz/nifeather/morph/providers/disguise/PlayerDisguiseProvider.java
@@ -20,8 +20,6 @@ import xyz.nifeather.morph.misc.DisguiseMeta;
 import xyz.nifeather.morph.misc.DisguiseState;
 import xyz.nifeather.morph.misc.DisguiseTypes;
 import xyz.nifeather.morph.misc.MorphGameProfile;
-import xyz.nifeather.morph.misc.disguiseProperty.DisguiseProperties;
-import xyz.nifeather.morph.misc.disguiseProperty.values.PlayerProperties;
 import xyz.nifeather.morph.misc.skins.PlayerSkinProvider;
 import xyz.nifeather.morph.network.commands.S2C.set.S2CSetProfileCommand;
 import xyz.nifeather.morph.network.server.MorphClientHandler;
@@ -72,10 +70,7 @@ public class PlayerDisguiseProvider extends DefaultDisguiseProvider
         if (DisguiseTypes.fromId(id) != DisguiseTypes.PLAYER)
             return DisguiseResult.fail();
 
-        var result = constructFromEntity(disguiseMeta, targetEntity);
-        var wrapper = result.success()
-                ? result.wrapperInstance()
-                : backend.createPlayerInstance(disguiseMeta.playerDisguiseTargetName);
+        var wrapper = backend.createPlayerInstance(disguiseMeta.playerDisguiseTargetName);
 
         Objects.requireNonNull(wrapper, "Null wrapper at where it shouldn't be?!");
 
@@ -126,9 +121,9 @@ public class PlayerDisguiseProvider extends DefaultDisguiseProvider
     private MorphClientHandler clientHandler;
 
     @Override
-    public void onPostConstructDisguise(DisguiseState state, @Nullable Entity targetEntity)
+    public void postBuildDisguise(DisguiseState state, @Nullable Entity targetEntity)
     {
-        super.onPostConstructDisguise(state, targetEntity);
+        super.postBuildDisguise(state, targetEntity);
 
         var wrapper = state.getDisguiseWrapper();
         var player = state.getPlayer();
@@ -192,8 +187,16 @@ public class PlayerDisguiseProvider extends DefaultDisguiseProvider
         return list;
     }
 
+    /**
+     * 我们是否可以克隆目标实体/玩家的伪装？
+     *
+     * @param info         {@link DisguiseMeta}
+     * @param targetEntity 目标实体
+     * @param theirState   他们的{@link DisguiseState}，如果有
+     * @return 是否允许克隆他们的装备进行显示
+     */
     @Override
-    public boolean canConstruct(DisguiseMeta info, Entity targetEntity, @Nullable DisguiseState theirState)
+    public boolean canCloneEquipment(DisguiseMeta info, Entity targetEntity, DisguiseState theirState)
     {
         if (theirState != null)
         {
@@ -207,27 +210,6 @@ public class PlayerDisguiseProvider extends DefaultDisguiseProvider
             return false;
 
         return targetPlayer.getName().equals(info.playerDisguiseTargetName);
-    }
-
-    /**
-     * 我们是否可以克隆目标实体/玩家的伪装？
-     *
-     * @param info         {@link DisguiseMeta}
-     * @param targetEntity 目标实体
-     * @param theirState   他们的{@link DisguiseState}，如果有
-     * @return 是否允许克隆他们的装备进行显示
-     */
-    @Override
-    public boolean canCloneEquipment(DisguiseMeta info, Entity targetEntity, DisguiseState theirState)
-    {
-        return canConstruct(info, targetEntity, theirState);
-    }
-
-    @Override
-    protected boolean canCloneDisguise(DisguiseMeta info, Entity targetEntity,
-                                       @NotNull DisguiseState theirState, @NotNull DisguiseWrapper<?> theirDisguise)
-    {
-        return theirDisguise.getDisguiseName().equals(info.playerDisguiseTargetName) && theirDisguise.isPlayerDisguise();
     }
 
     @Override

--- a/src/main/java/xyz/nifeather/morph/providers/disguise/PlayerDisguiseProvider.java
+++ b/src/main/java/xyz/nifeather/morph/providers/disguise/PlayerDisguiseProvider.java
@@ -3,13 +3,11 @@ package xyz.nifeather.morph.providers.disguise;
 import com.mojang.authlib.GameProfile;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import net.kyori.adventure.text.Component;
-import net.minecraft.nbt.CompoundTag;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.MainHand;
 import org.bukkit.inventory.meta.SkullMeta;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -121,38 +119,11 @@ public class PlayerDisguiseProvider extends DefaultDisguiseProvider
 
         //endregion Player Skin
 
-        return DisguiseResult.success(wrapper, result.isCopy());
+        return DisguiseResult.success(wrapper);
     }
 
     @Resolved(shouldSolveImmediately = true)
     private MorphClientHandler clientHandler;
-
-    @Override
-    public void setupProperties(DisguiseState state, @Nullable Entity targetEntity)
-    {
-        if (!(targetEntity instanceof Player targetPlayer))
-            return;
-
-        var propertyHandler = state.disguisePropertyHandler();
-        var playerProperties = DisguiseProperties.INSTANCE.getOrThrow(PlayerProperties.class);
-
-        if (!propertyHandler.contains(playerProperties.MAIN_HAND)) //todo: Remove this when we deprecated NBT usage
-            propertyHandler.set(playerProperties.MAIN_HAND, targetPlayer.getMainHand());
-
-        super.setupProperties(state, targetEntity);
-    }
-
-    //todo: Remove this when we deprecated NBT usage
-    private void setupPropertiesNBT(DisguiseState state, @Nullable Entity targetEntity)
-    {
-        if (!(targetEntity instanceof Player targetPlayer))
-            return;
-
-        CompoundTag compoundTag = new CompoundTag();
-        compoundTag.putBoolean("feathermorph:is_left_hand", targetPlayer.getMainHand() == MainHand.LEFT);
-
-        state.getDisguiseWrapper().mergeCompound(compoundTag);
-    }
 
     @Override
     public void onPostConstructDisguise(DisguiseState state, @Nullable Entity targetEntity)
@@ -161,9 +132,6 @@ public class PlayerDisguiseProvider extends DefaultDisguiseProvider
 
         var wrapper = state.getDisguiseWrapper();
         var player = state.getPlayer();
-
-        //todo: Remove this when we deprecated NBT usage
-        setupPropertiesNBT(state, targetEntity);
 
         wrapper.subscribeEvent(this, WrapperEvent.SKIN_SET, skin ->
                 clientHandler.sendCommand(player, new S2CSetProfileCommand(state.getProfileNbtString())));
@@ -266,16 +234,6 @@ public class PlayerDisguiseProvider extends DefaultDisguiseProvider
     public boolean validForClient(DisguiseState state)
     {
         return true;
-    }
-
-    @Override
-    public @Nullable CompoundTag getInitialNbtCompound(DisguiseState state, @Nullable Entity targetEntity, boolean enableCulling)
-    {
-        if (!(targetEntity instanceof Player targetPlayer)) return null;
-
-        if (!targetPlayer.getName().equals(DisguiseTypes.PLAYER.toStrippedId(state.getDisguiseIdentifier()))) return null;
-
-        return super.getInitialNbtCompound(state, targetEntity, enableCulling);
     }
 
     @Override

--- a/src/main/java/xyz/nifeather/morph/providers/disguise/VanillaDisguiseProvider.java
+++ b/src/main/java/xyz/nifeather/morph/providers/disguise/VanillaDisguiseProvider.java
@@ -2,7 +2,6 @@ package xyz.nifeather.morph.providers.disguise;
 
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import net.kyori.adventure.text.Component;
-import net.minecraft.nbt.CompoundTag;
 import org.bukkit.NamespacedKey;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.attribute.AttributeInstance;
@@ -27,6 +26,7 @@ import xyz.nifeather.morph.misc.DisguiseTypes;
 import xyz.nifeather.morph.misc.NmsRecord;
 import xyz.nifeather.morph.misc.disguiseProperty.DisguiseProperties;
 import xyz.nifeather.morph.misc.disguiseProperty.values.ArmorStandProperties;
+import xyz.nifeather.morph.misc.disguiseProperty.values.SlimeMagmaProperties;
 import xyz.nifeather.morph.providers.animation.AnimationProvider;
 import xyz.nifeather.morph.providers.animation.provider.VanillaAnimationProvider;
 import xyz.nifeather.morph.utilities.*;
@@ -134,24 +134,6 @@ public class VanillaDisguiseProvider extends DefaultDisguiseProvider
         // Make IDE happy
         Objects.requireNonNull(constructedDisguise);
 
-        var canConstructFromEntity = canConstruct(disguiseMeta, targetEntity, null);
-
-        //手动指定史莱姆和岩浆怪的大小
-        if (entityType == EntityType.SLIME || entityType == EntityType.MAGMA_CUBE)
-        {
-            if (canConstructFromEntity)
-            {
-                var size = (targetEntity instanceof Slime slime)
-                        ? slime.getSize()
-                        : new Random().nextInt(0, 4); //史莱姆的大小其实是0~3
-
-                var initialTag = new CompoundTag();
-
-                initialTag.putInt("Size", size);
-                constructedDisguise.mergeCompound(initialTag);
-            }
-        }
-
         // 检查是否有足够的空间
         if (modifyBoundingBoxes.get() && checkSpaceBoundingBox.get())
         {
@@ -166,7 +148,7 @@ public class VanillaDisguiseProvider extends DefaultDisguiseProvider
             }
         }
 
-        return DisguiseResult.success(constructedDisguise, copyResult.isCopy());
+        return DisguiseResult.success(constructedDisguise);
     }
 
     @Override
@@ -438,27 +420,6 @@ public class VanillaDisguiseProvider extends DefaultDisguiseProvider
             tryModifyPlayerDimensions(player, state.getDisguiseWrapper());
 
         mutePlayerWaypoint(player);
-    }
-
-    @Override
-    public @Nullable CompoundTag getInitialNbtCompound(DisguiseState state, @Nullable Entity targetEntity, boolean enableCulling)
-    {
-        var info = getMorphManager().getDisguiseMeta(state.getDisguiseIdentifier());
-
-        var rawCompound = targetEntity != null && canConstruct(info, targetEntity, null)
-                ? NbtUtils.getRawTagCompound(targetEntity)
-                : new CompoundTag();
-
-        var theirDisguise = getMorphManager().getDisguiseStateFor(targetEntity);
-
-        if (theirDisguise != null)
-            rawCompound = theirDisguise.getDisguiseWrapper().getCompound();
-
-        // ???
-        // if (targetEntity == null || targetEntity.getType() != state.getEntityType())
-        //    rawCompound.merge(state.getDisguiseWrapper().getCompound());
-
-        return enableCulling ? cullNBT(rawCompound) : rawCompound;
     }
 
     @Override

--- a/src/main/java/xyz/nifeather/morph/providers/disguise/VanillaDisguiseProvider.java
+++ b/src/main/java/xyz/nifeather/morph/providers/disguise/VanillaDisguiseProvider.java
@@ -26,7 +26,6 @@ import xyz.nifeather.morph.misc.DisguiseTypes;
 import xyz.nifeather.morph.misc.NmsRecord;
 import xyz.nifeather.morph.misc.disguiseProperty.DisguiseProperties;
 import xyz.nifeather.morph.misc.disguiseProperty.values.ArmorStandProperties;
-import xyz.nifeather.morph.misc.disguiseProperty.values.SlimeMagmaProperties;
 import xyz.nifeather.morph.providers.animation.AnimationProvider;
 import xyz.nifeather.morph.providers.animation.provider.VanillaAnimationProvider;
 import xyz.nifeather.morph.utilities.*;
@@ -34,7 +33,6 @@ import xyz.nifeather.morph.utilities.*;
 import java.lang.reflect.Field;
 import java.util.List;
 import java.util.Objects;
-import java.util.Random;
 
 public class VanillaDisguiseProvider extends DefaultDisguiseProvider
 {
@@ -114,7 +112,6 @@ public class VanillaDisguiseProvider extends DefaultDisguiseProvider
     {
         var identifier = disguiseMeta.getIdentifier();
 
-        DisguiseWrapper<?> constructedDisguise;
         var backend = getPreferredBackend();
 
         var entityType = EntityTypeUtils.fromString(identifier, true);
@@ -125,20 +122,16 @@ public class VanillaDisguiseProvider extends DefaultDisguiseProvider
             return DisguiseResult.fail();
         }
 
-        var copyResult = constructFromEntity(disguiseMeta, targetEntity);
-
-        constructedDisguise = copyResult.success()
-                ? copyResult.wrapperInstance() //copyResult.success() -> wrapperInstance() != null
-                : backend.createInstance(entityType);
+        var newDisguise = backend.createInstance(entityType);
 
         // Make IDE happy
-        Objects.requireNonNull(constructedDisguise);
+        Objects.requireNonNull(newDisguise);
 
         // 检查是否有足够的空间
         if (modifyBoundingBoxes.get() && checkSpaceBoundingBox.get())
         {
             var loc = player.getLocation();
-            var box = constructedDisguise.getBoundingBoxAt(loc.x(), loc.y(), loc.z());
+            var box = newDisguise.getBoundingBoxAt(loc.x(), loc.y(), loc.z());
 
             var hasCollision = CollisionUtils.hasCollisionWithBlockOrBorder(player, box);
             if (hasCollision)
@@ -148,7 +141,7 @@ public class VanillaDisguiseProvider extends DefaultDisguiseProvider
             }
         }
 
-        return DisguiseResult.success(constructedDisguise);
+        return DisguiseResult.success(newDisguise);
     }
 
     @Override
@@ -169,9 +162,9 @@ public class VanillaDisguiseProvider extends DefaultDisguiseProvider
     }
 
     @Override
-    public void onPostConstructDisguise(DisguiseState state, @Nullable Entity targetEntity)
+    public void postBuildDisguise(DisguiseState state, @Nullable Entity targetEntity)
     {
-        super.onPostConstructDisguise(state, targetEntity);
+        super.postBuildDisguise(state, targetEntity);
 
         var wrapper = state.getDisguiseWrapper();
         var theirDisguise = getMorphManager().getDisguiseStateFor(targetEntity);
@@ -385,25 +378,20 @@ public class VanillaDisguiseProvider extends DefaultDisguiseProvider
     }
 
     @Override
-    public void resetDisguise(DisguiseState state)
-    {
-        var player = state.getPlayer();
-
-        removeAllHealthModifiers(player);
-        resetPlayerDimensions(player);
-        recoverPlayerWaypoint(player);
-    }
-
-    @Override
     public boolean unMorph(Player player, DisguiseState state)
     {
         if (super.unMorph(player, state))
         {
-            resetDisguise(state);
+            removeAllHealthModifiers(player);
+            resetPlayerDimensions(player);
+            recoverPlayerWaypoint(player);
+
             return true;
         }
         else
+        {
             return false;
+        }
     }
 
     @Override
@@ -428,14 +416,6 @@ public class VanillaDisguiseProvider extends DefaultDisguiseProvider
         return true;
     }
 
-    @Override
-    public boolean canConstruct(DisguiseMeta info, @Nullable Entity targetEntity, DisguiseState theirState)
-    {
-        return theirState != null
-                ? theirState.getDisguiseWrapper().getEntityType().equals(info.getEntityType())
-                : targetEntity == null || targetEntity.getType().equals(info.getEntityType());
-    }
-
     /**
      * 我们是否可以克隆目标实体/玩家的伪装？
      *
@@ -447,14 +427,9 @@ public class VanillaDisguiseProvider extends DefaultDisguiseProvider
     @Override
     public boolean canCloneEquipment(DisguiseMeta info, Entity targetEntity, DisguiseState theirState)
     {
-        return canConstruct(info, targetEntity, theirState);
-    }
-
-    @Override
-    protected boolean canCloneDisguise(DisguiseMeta info, Entity targetEntity,
-                                       @NotNull DisguiseState theirDisguiseState, @NotNull DisguiseWrapper<?> theirDisguise)
-    {
-        return theirDisguise.getEntityType().equals(info.getEntityType());
+        return theirState != null
+                ? theirState.getDisguiseWrapper().getEntityType().equals(info.getEntityType())
+                : targetEntity == null || targetEntity.getType().equals(info.getEntityType());
     }
 
     @Resolved

--- a/src/main/java/xyz/nifeather/morph/storage/offlinestore/OfflineDisguiseState.java
+++ b/src/main/java/xyz/nifeather/morph/storage/offlinestore/OfflineDisguiseState.java
@@ -41,12 +41,6 @@ public class OfflineDisguiseState implements IOfflineState
     public boolean displayingDisguisedItems;
 
     /**
-     * 伪装的NBT数据（如果有）
-     */
-    @Expose
-    public String snbt;
-
-    /**
      * 伪装的{@link com.mojang.authlib.GameProfile}数据（如果有）
      */
     @Expose

--- a/src/main/java/xyz/nifeather/morph/utilities/DisguiseUtils.java
+++ b/src/main/java/xyz/nifeather/morph/utilities/DisguiseUtils.java
@@ -19,6 +19,7 @@ import xyz.nifeather.morph.misc.NmsRecord;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
 
 public class DisguiseUtils
 {
@@ -136,4 +137,16 @@ public class DisguiseUtils
     }
 
     //endregion Ambient sound
+
+    public static <X> X pick(List<X> list)
+    {
+        var random = ThreadLocalRandom.current();
+        return list.get(random.nextInt(list.size()));
+    }
+
+    public static <X> X pick(X[] array)
+    {
+        var random = ThreadLocalRandom.current();
+        return array[random.nextInt(array.length)];
+    }
 }

--- a/src/main/java/xyz/nifeather/morph/utilities/MathUtils.java
+++ b/src/main/java/xyz/nifeather/morph/utilities/MathUtils.java
@@ -2,6 +2,8 @@ package xyz.nifeather.morph.utilities;
 
 import org.bukkit.util.Vector;
 
+import java.util.Optional;
+
 public class MathUtils
 {
     public static int clamp(int min, int max, int val)
@@ -49,5 +51,18 @@ public class MathUtils
         }
 
         return defaultValue;
+    }
+
+    public static Optional<Integer> parseIntOrEmpty(String input)
+    {
+        try
+        {
+            return Optional.of(Integer.parseInt(input));
+        }
+        catch (Throwable ignored)
+        {
+        }
+
+        return Optional.empty();
     }
 }

--- a/src/main/java/xyz/nifeather/morph/utilities/MathUtils.java
+++ b/src/main/java/xyz/nifeather/morph/utilities/MathUtils.java
@@ -37,4 +37,17 @@ public class MathUtils
     {
         return a > b ? a : Math.max(b, c);
     }
+
+    public static int parseIntOr(String input, int defaultValue)
+    {
+        try
+        {
+            return Integer.parseInt(input);
+        }
+        catch (Throwable ignored)
+        {
+        }
+
+        return defaultValue;
+    }
 }


### PR DESCRIPTION
## Summary
This PR aims to replace the usage of NBT to Disguise Properties for disguise building and syncing, which can help reduce the dependence on NMS components.

This makes the server command API bumped from 14 (`WE_NOW_USE_JSON`) to 15 (`NETWORK_DISGUISE_PROPERTIES`), making it incompatible with clients implementing API 14.

Permission for this feature ( Disguise Property ) is currently not planned, as it's one of the plugin's core features.

## Compatibility
However, backward compatibility is maintained for now, as some people may still use old clients that don't support the API 15 protocols. Backward compatibility is planned to be removed when...
- 1.22 released
- We reached 2026

When backward compatibility reaches the end, the plugin will reject any clients that are implementing legacy APIs ( They will not be able to use the client integration! ).

## Other...
Since we no longer use the NBT, it makes it possible for us to open more options for players when disguising. Currently, the most noticeable change is that player disguise is now possible to override the main hand ( `player/main_hand` ) and arrows on the player( `entity/stucked_arrows` ).

For initial client implementation, see [FeatherMorphClient >> Latest CI build](https://github.com/NiFeather/FeatherMorphClient/actions)